### PR TITLE
During expression equality, check for new ordering information

### DIFF
--- a/datafusion/physical-expr/src/equivalence/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/mod.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use crate::expressions::Column;
-use crate::sort_properties::SortProperties;
 use crate::{LexRequirement, PhysicalExpr, PhysicalSortRequirement};
 
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
@@ -47,48 +46,8 @@ pub fn collapse_lex_req(input: LexRequirement) -> LexRequirement {
             output.push(item);
         }
     }
-    collapse_monotonic_lex_req(output)
-}
-
-/// This function constructs a normalized [`LexRequirement`] by filtering out entries
-/// that are ordered if the next entry is.
-/// Used in `collapse_lex_req`
-fn collapse_monotonic_lex_req(input: LexRequirement) -> LexRequirement {
-    input
-        .iter()
-        .enumerate()
-        .filter_map(|(i, item)| {
-            // If it's the last entry, there is no next entry
-            if i == input.len() - 1 {
-                return Some(item);
-            }
-            let next_expr = &input[i + 1];
-
-            // Only handle expressions with exactly one child
-            // TODO: it should be possible to handle expressions orderings f(a, b, c), a, b, c
-            // if f is monotonic in all arguments
-            if !(item.expr.children().len() == 1
-                && item.expr.children()[0].eq(&next_expr.expr))
-            {
-                return Some(item);
-            }
-
-            let opts = match next_expr.options {
-                None => return Some(item),
-                Some(opts) => opts,
-            };
-
-            if item.options.map(SortProperties::Ordered)
-                == Some(item.expr.get_ordering(&[SortProperties::Ordered(opts)]))
-            {
-                // Remove the redundant sort
-                return None;
-            }
-
-            Some(item)
-        })
-        .cloned()
-        .collect::<Vec<_>>()
+    // collapse_monotonic_lex_req(output)
+    output
 }
 
 /// Adds the `offset` value to `Column` indices inside `expr`. This function is

--- a/datafusion/physical-expr/src/equivalence/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/mod.rs
@@ -46,7 +46,6 @@ pub fn collapse_lex_req(input: LexRequirement) -> LexRequirement {
             output.push(item);
         }
     }
-    // collapse_monotonic_lex_req(output)
     output
 }
 

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -2305,7 +2305,7 @@ mod tests {
             TestCase {
                 name: "(a, b, c) -> (c)",
                 // b is constant, so it should be removed from the sort order
-                constants: vec![col_b],
+                constants: vec![col_b.clone()],
                 equal_conditions: vec![[cast_c.clone(), col_a.clone()]],
                 sort_columns: &["c"],
                 should_satisfy_ordering: true,

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -198,7 +198,7 @@ impl EquivalenceProperties {
         left: &Arc<dyn PhysicalExpr>,
         right: &Arc<dyn PhysicalExpr>,
     ) {
-        // Discover new constants in the light of new ordering
+        // Discover new constants in light of new the equality:
         if self.is_expr_constant(left) {
             // Left expression is constant, add right as constant
             if !physical_exprs_contains(&self.constants, right) {
@@ -211,8 +211,8 @@ impl EquivalenceProperties {
             }
         }
 
-        // Discover new valid orderings in the light of new equality
-        // See issue: https://github.com/apache/datafusion/issues/9812 for rationale
+        // Discover new valid orderings in light of the new equality. For a discussion, see:
+        // https://github.com/apache/datafusion/issues/9812
         let mut new_orderings = vec![];
         for ordering in self.normalized_oeq_class().iter() {
             let expressions = if left.eq(&ordering[0].expr) {

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -2310,6 +2310,16 @@ mod tests {
                 sort_columns: &["c"],
                 should_satisfy_ordering: true,
             },
+            // Same test with above test, where equality order is swapped.
+            // Algorithm shouldn't depend on this order.
+            TestCase {
+                name: "(a, b, c) -> (c)",
+                // b is constant, so it should be removed from the sort order
+                constants: vec![col_b],
+                equal_conditions: vec![[col_a.clone(), cast_c.clone()]],
+                sort_columns: &["c"],
+                should_satisfy_ordering: true,
+            },
             TestCase {
                 name: "not ordered because (b) is not constant",
                 // b is not constant anymore


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
See [issue9812](https://github.com/apache/datafusion/issues/9812) for rationale.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
When an equality expression is added to the `EquivalenceProperties`. In light of this information, we can deduce new information about ordering and constantness. This PR adds this support. 

With the [PR](https://github.com/apache/datafusion/pull/9813) we have this support, in terms of behaviour. However, current solution doesn't update state and cannot generalize well.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
There is an additional TestCase, that showcases increased coverage with this implementation (That test case fails in main branch).
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
