### PR TITLE
bench: Replace `RoundRobinBatch` with `OnDemandRepartition`

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -156,6 +156,9 @@ main() {
                 tpch10)
                     data_tpch "10"
                     ;;
+                tpch50)
+                    data_tpch "50"
+                    ;;
                 tpch_mem10)
                     # same data as for tpch10
                     data_tpch "10"
@@ -232,6 +235,9 @@ main() {
                     ;;
                 tpch10)
                     run_tpch "10"
+                    ;;
+                tpch50)
+                    run_tpch "50"
                     ;;
                 tpch_mem10)
                     run_tpch_mem "10"

--- a/benchmarks/src/tpch/convert.rs
+++ b/benchmarks/src/tpch/convert.rs
@@ -95,7 +95,7 @@ impl ConvertOpt {
             // optionally, repartition the file
             let partitions = self.partitions;
             if partitions > 1 {
-                csv = csv.repartition(Partitioning::RoundRobinBatch(partitions))?
+                csv = csv.repartition(Partitioning::OnDemand(partitions))?
             }
 
             // create the physical plan

--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -121,8 +121,6 @@ impl RunOpt {
             .config()
             .with_collect_statistics(!self.disable_statistics);
         config.options_mut().optimizer.prefer_hash_join = self.prefer_hash_join;
-        config.options_mut().optimizer.enable_on_demand_repartition = true;
-        config.options_mut().optimizer.enable_round_robin_repartition = false;
         let ctx = SessionContext::new_with_config(config);
 
         // register tables

--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -121,6 +121,8 @@ impl RunOpt {
             .config()
             .with_collect_statistics(!self.disable_statistics);
         config.options_mut().optimizer.prefer_hash_join = self.prefer_hash_join;
+        config.options_mut().optimizer.enable_on_demand_repartition = true;
+        config.options_mut().optimizer.enable_round_robin_repartition = false;
         let ctx = SessionContext::new_with_config(config);
 
         // register tables

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -532,6 +532,8 @@ config_namespace! {
         /// repartitioning to increase parallelism to leverage more CPU cores
         pub enable_round_robin_repartition: bool, default = true
 
+        pub enable_on_demand_repartition: bool, default = true
+
         /// When set to true, the optimizer will attempt to perform limit operations
         /// during aggregations, if possible
         pub enable_topk_aggregation: bool, default = true

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -45,6 +45,7 @@ use datafusion_expr::SortExpr;
 use datafusion_physical_plan::metrics::MetricsSet;
 
 use async_trait::async_trait;
+use datafusion_physical_plan::repartition::on_demand_repartition::OnDemandRepartitionExec;
 use futures::StreamExt;
 use log::debug;
 use parking_lot::Mutex;
@@ -165,9 +166,14 @@ impl MemTable {
         let exec = MemoryExec::try_new(&data, Arc::clone(&schema), None)?;
 
         if let Some(num_partitions) = output_partitions {
-            let exec = RepartitionExec::try_new(
+            // TODO: replaced with OnDemandRepartitionExec
+            // let exec = RepartitionExec::try_new(
+            //     Arc::new(exec),
+            //     Partitioning::RoundRobinBatch(num_partitions),
+            // )?;
+            let exec = OnDemandRepartitionExec::try_new(
                 Arc::new(exec),
-                Partitioning::RoundRobinBatch(num_partitions),
+                Partitioning::OnDemand(num_partitions),
             )?;
 
             // execute and collect results

--- a/datafusion/core/src/physical_optimizer/enforce_sorting.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_sorting.rs
@@ -548,6 +548,11 @@ fn remove_bottleneck_in_subplan(
         if let Partitioning::RoundRobinBatch(n_out) = repartition.partitioning() {
             can_remove |= *n_out == input_partitioning.partition_count();
         }
+        // TODO: replaced with OnDemand
+        if let Partitioning::OnDemand(n_out) = repartition.partitioning() {
+            can_remove |= *n_out == input_partitioning.partition_count();
+        }
+
         if can_remove {
             new_reqs = new_reqs.children.swap_remove(0)
         }

--- a/datafusion/core/src/physical_optimizer/sort_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/sort_pushdown.rs
@@ -41,6 +41,7 @@ use datafusion_physical_expr::PhysicalSortRequirement;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, LexRequirement};
 use datafusion_physical_plan::joins::utils::ColumnIndex;
 use datafusion_physical_plan::joins::HashJoinExec;
+use datafusion_physical_plan::repartition::on_demand_repartition::OnDemandRepartitionExec;
 
 /// This is a "data class" we use within the [`EnforceSorting`] rule to push
 /// down [`SortExec`] in the plan. In some cases, we can reduce the total
@@ -271,6 +272,7 @@ fn pushdown_requirement_to_children(
     } else if maintains_input_order.is_empty()
         || !maintains_input_order.iter().any(|o| *o)
         || plan.as_any().is::<RepartitionExec>()
+        || plan.as_any().is::<OnDemandRepartitionExec>()
         || plan.as_any().is::<FilterExec>()
         // TODO: Add support for Projection push down
         || plan.as_any().is::<ProjectionExec>()

--- a/datafusion/core/src/physical_optimizer/test_utils.rs
+++ b/datafusion/core/src/physical_optimizer/test_utils.rs
@@ -51,6 +51,7 @@ use datafusion_expr::{WindowFrame, WindowFunctionDefinition};
 use datafusion_functions_aggregate::count::count_udaf;
 use datafusion_physical_expr::expressions::col;
 use datafusion_physical_expr::{PhysicalExpr, PhysicalSortExpr};
+use datafusion_physical_plan::repartition::on_demand_repartition::OnDemandRepartitionExec;
 use datafusion_physical_plan::tree_node::PlanContext;
 use datafusion_physical_plan::{
     displayable, DisplayAs, DisplayFormatType, PlanProperties,
@@ -324,7 +325,7 @@ pub fn global_limit_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan
 
 pub fn repartition_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
     // TODO: replace with OnDemand
-    Arc::new(RepartitionExec::try_new(input, Partitioning::OnDemand(10)).unwrap())
+    Arc::new(OnDemandRepartitionExec::try_new(input, Partitioning::OnDemand(10)).unwrap())
     // Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(10)).unwrap())
 }
 
@@ -336,7 +337,7 @@ pub fn spr_repartition_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionP
     //         .with_preserve_order(),
     // )
     Arc::new(
-        RepartitionExec::try_new(input, Partitioning::OnDemand(10))
+        OnDemandRepartitionExec::try_new(input, Partitioning::OnDemand(10))
             .unwrap()
             .with_preserve_order(),
     )

--- a/datafusion/core/src/physical_optimizer/test_utils.rs
+++ b/datafusion/core/src/physical_optimizer/test_utils.rs
@@ -323,12 +323,20 @@ pub fn global_limit_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan
 }
 
 pub fn repartition_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-    Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(10)).unwrap())
+    // TODO: replace with OnDemand
+    Arc::new(RepartitionExec::try_new(input, Partitioning::OnDemand(10)).unwrap())
+    // Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(10)).unwrap())
 }
 
 pub fn spr_repartition_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    // TODO: replaced with OnDemand
+    // Arc::new(
+    //     RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(10))
+    //         .unwrap()
+    //         .with_preserve_order(),
+    // )
     Arc::new(
-        RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(10))
+        RepartitionExec::try_new(input, Partitioning::OnDemand(10))
             .unwrap()
             .with_preserve_order(),
     )

--- a/datafusion/core/src/physical_optimizer/utils.rs
+++ b/datafusion/core/src/physical_optimizer/utils.rs
@@ -30,6 +30,7 @@ use crate::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_physical_expr::LexRequirement;
 use datafusion_physical_expr_common::sort_expr::LexOrdering;
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
+use datafusion_physical_plan::repartition::on_demand_repartition::OnDemandRepartitionExec;
 use datafusion_physical_plan::tree_node::PlanContext;
 
 /// This utility function adds a `SortExec` above an operator according to the
@@ -107,4 +108,9 @@ pub fn is_union(plan: &Arc<dyn ExecutionPlan>) -> bool {
 /// Checks whether the given operator is a [`RepartitionExec`].
 pub fn is_repartition(plan: &Arc<dyn ExecutionPlan>) -> bool {
     plan.as_any().is::<RepartitionExec>()
+}
+
+/// Checks whether the given operator is a [`OnDemandRepartitionExec`].
+pub fn is_on_demand_repartition(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    plan.as_any().is::<OnDemandRepartitionExec>()
 }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -788,8 +788,10 @@ impl DefaultPhysicalPlanner {
                 let physical_input = children.one()?;
                 let input_dfschema = input.as_ref().schema();
                 let physical_partitioning = match partitioning_scheme {
-                    LogicalPartitioning::RoundRobinBatch(n) => {
-                        Partitioning::RoundRobinBatch(*n)
+                    LogicalPartitioning::RoundRobinBatch(n)
+                    | LogicalPartitioning::OnDemand(n) => {
+                        // TODO: replaced by OnDemand
+                        Partitioning::OnDemand(*n)
                     }
                     LogicalPartitioning::Hash(expr, n) => {
                         let runtime_expr = expr

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -84,6 +84,7 @@ use datafusion_physical_expr::aggregate::{AggregateExprBuilder, AggregateFunctio
 use datafusion_physical_expr::expressions::Literal;
 use datafusion_physical_expr::LexOrdering;
 use datafusion_physical_plan::placeholder_row::PlaceholderRowExec;
+use datafusion_physical_plan::repartition::on_demand_repartition::OnDemandRepartitionExec;
 use datafusion_physical_plan::unnest::ListUnnest;
 use datafusion_sql::utils::window_expr_common_partition_keys;
 
@@ -791,7 +792,11 @@ impl DefaultPhysicalPlanner {
                     LogicalPartitioning::RoundRobinBatch(n)
                     | LogicalPartitioning::OnDemand(n) => {
                         // TODO: replaced by OnDemand
-                        Partitioning::OnDemand(*n)
+
+                        return Ok(Arc::new(OnDemandRepartitionExec::try_new(
+                            physical_input,
+                            Partitioning::OnDemand(*n),
+                        )?));
                     }
                     LogicalPartitioning::Hash(expr, n) => {
                         let runtime_expr = expr

--- a/datafusion/core/tests/fuzz_cases/sort_preserving_repartition_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_preserving_repartition_fuzz.rs
@@ -43,6 +43,7 @@ mod sp_repartition_fuzz_tests {
         expressions::{col, Column},
         ConstExpr, PhysicalExpr, PhysicalSortExpr,
     };
+    use datafusion_physical_plan::repartition::on_demand_repartition::OnDemandRepartitionExec;
     use test_utils::add_empty_batches;
 
     use datafusion_physical_expr_common::sort_expr::LexOrdering;
@@ -390,8 +391,14 @@ mod sp_repartition_fuzz_tests {
     fn sort_preserving_repartition_exec_round_robin(
         input: Arc<dyn ExecutionPlan>,
     ) -> Arc<dyn ExecutionPlan> {
+        // TODO: replaced with OnDemandRepartitionExec
+        // Arc::new(
+        //     RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(2))
+        //         .unwrap()
+        //         .with_preserve_order(),
+        // )
         Arc::new(
-            RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(2))
+            OnDemandRepartitionExec::try_new(input, Partitioning::OnDemand(2))
                 .unwrap()
                 .with_preserve_order(),
         )
@@ -400,8 +407,12 @@ mod sp_repartition_fuzz_tests {
     fn repartition_exec_round_robin(
         input: Arc<dyn ExecutionPlan>,
     ) -> Arc<dyn ExecutionPlan> {
+        // TODO: replaced with OnDemandRepartitionExec
+        // Arc::new(
+        //     RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(2)).unwrap(),
+        // )
         Arc::new(
-            RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(2)).unwrap(),
+            OnDemandRepartitionExec::try_new(input, Partitioning::OnDemand(2)).unwrap(),
         )
     }
 

--- a/datafusion/core/tests/physical_optimizer/combine_partial_final_agg.rs
+++ b/datafusion/core/tests/physical_optimizer/combine_partial_final_agg.rs
@@ -34,6 +34,7 @@ use datafusion_physical_plan::aggregates::{
     AggregateExec, AggregateMode, PhysicalGroupBy,
 };
 use datafusion_physical_plan::displayable;
+use datafusion_physical_plan::repartition::on_demand_repartition::OnDemandRepartitionExec;
 use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::ExecutionPlan;
 
@@ -122,7 +123,8 @@ fn final_aggregate_exec(
 }
 
 fn repartition_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-    Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(10)).unwrap())
+    // Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(10)).unwrap())
+    Arc::new(OnDemandRepartitionExec::try_new(input, Partitioning::OnDemand(10)).unwrap())
 }
 
 // Return appropriate expr depending if COUNT is for col or table (*)
@@ -157,7 +159,7 @@ fn aggregations_not_combined() -> datafusion_common::Result<()> {
     // should not combine the Partial/Final AggregateExecs
     let expected = &[
         "AggregateExec: mode=Final, gby=[], aggr=[COUNT(1)]",
-        "RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1",
+        "OnDemandRepartitionExec: partitioning=OnDemand(10), input_partitions=1",
         "AggregateExec: mode=Partial, gby=[], aggr=[COUNT(1)]",
         "ParquetExec: file_groups={1 group: [[x]]}, projection=[a, b, c]",
     ];

--- a/datafusion/core/tests/sql/explain_analyze.rs
+++ b/datafusion/core/tests/sql/explain_analyze.rs
@@ -616,7 +616,7 @@ async fn test_physical_plan_display_indent() {
         "            AggregateExec: mode=Partial, gby=[c1@0 as c1], aggr=[max(aggregate_test_100.c12), min(aggregate_test_100.c12)]",
         "              CoalesceBatchesExec: target_batch_size=4096",
         "                FilterExec: c12@1 < 10",
-        "                  RepartitionExec: partitioning=RoundRobinBatch(9000), input_partitions=1",
+        "                  OnDemandRepartitionExec: partitioning=OnDemand(9000), input_partitions=1",
         "                    CsvExec: file_groups={1 group: [[ARROW_TEST_DATA/csv/aggregate_test_100.csv]]}, projection=[c1, c12], has_header=true",
     ];
 
@@ -656,11 +656,11 @@ async fn test_physical_plan_display_indent_multi_children() {
     	"  HashJoinExec: mode=Partitioned, join_type=Inner, on=[(c1@0, c2@0)], projection=[c1@0]",
     	"    CoalesceBatchesExec: target_batch_size=4096",
     	"      RepartitionExec: partitioning=Hash([c1@0], 9000), input_partitions=9000",
-    	"        RepartitionExec: partitioning=RoundRobinBatch(9000), input_partitions=1",
+    	"        OnDemandRepartitionExec: partitioning=OnDemand(9000), input_partitions=1",
     	"          CsvExec: file_groups={1 group: [[ARROW_TEST_DATA/csv/aggregate_test_100.csv]]}, projection=[c1], has_header=true",
     	"    CoalesceBatchesExec: target_batch_size=4096",
     	"      RepartitionExec: partitioning=Hash([c2@0], 9000), input_partitions=9000",
-    	"        RepartitionExec: partitioning=RoundRobinBatch(9000), input_partitions=1",
+    	"        OnDemandRepartitionExec: partitioning=OnDemand(9000), input_partitions=1",
     	"          ProjectionExec: expr=[c1@0 as c2]",
     	"            CsvExec: file_groups={1 group: [[ARROW_TEST_DATA/csv/aggregate_test_100.csv]]}, projection=[c1], has_header=true",
     ];

--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -66,11 +66,11 @@ async fn join_change_in_planner() -> Result<()> {
             "SymmetricHashJoinExec: mode=Partitioned, join_type=Full, on=[(a2@1, a2@1)], filter=CAST(a1@0 AS Int64) > CAST(a1@1 AS Int64) + 3 AND CAST(a1@0 AS Int64) < CAST(a1@1 AS Int64) + 10",
             "  CoalesceBatchesExec: target_batch_size=8192",
             "    RepartitionExec: partitioning=Hash([a2@1], 8), input_partitions=8, preserve_order=true, sort_exprs=a1@0 ASC NULLS LAST",
-            "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+            "      OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1",
             // "     CsvExec: file_groups={1 group: [[tempdir/left.csv]]}, projection=[a1, a2], has_header=false",
             "  CoalesceBatchesExec: target_batch_size=8192",
             "    RepartitionExec: partitioning=Hash([a2@1], 8), input_partitions=8, preserve_order=true, sort_exprs=a1@0 ASC NULLS LAST",
-            "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+            "      OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1",
             // "     CsvExec: file_groups={1 group: [[tempdir/right.csv]]}, projection=[a1, a2], has_header=false"
         ]
     };
@@ -134,11 +134,11 @@ async fn join_no_order_on_filter() -> Result<()> {
             "SymmetricHashJoinExec: mode=Partitioned, join_type=Full, on=[(a2@1, a2@1)], filter=CAST(a3@0 AS Int64) > CAST(a3@1 AS Int64) + 3 AND CAST(a3@0 AS Int64) < CAST(a3@1 AS Int64) + 10",
             "  CoalesceBatchesExec: target_batch_size=8192",
             "    RepartitionExec: partitioning=Hash([a2@1], 8), input_partitions=8",
-            "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+            "      OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1",
             // "     CsvExec: file_groups={1 group: [[tempdir/left.csv]]}, projection=[a1, a2], has_header=false",
             "  CoalesceBatchesExec: target_batch_size=8192",
             "    RepartitionExec: partitioning=Hash([a2@1], 8), input_partitions=8",
-            "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+            "      OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1",
             // "     CsvExec: file_groups={1 group: [[tempdir/right.csv]]}, projection=[a1, a2], has_header=false"
         ]
     };
@@ -184,11 +184,11 @@ async fn join_change_in_planner_without_sort() -> Result<()> {
             "SymmetricHashJoinExec: mode=Partitioned, join_type=Full, on=[(a2@1, a2@1)], filter=CAST(a1@0 AS Int64) > CAST(a1@1 AS Int64) + 3 AND CAST(a1@0 AS Int64) < CAST(a1@1 AS Int64) + 10",
             "  CoalesceBatchesExec: target_batch_size=8192",
             "    RepartitionExec: partitioning=Hash([a2@1], 8), input_partitions=8",
-            "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+            "      OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1",
             // "     CsvExec: file_groups={1 group: [[tempdir/left.csv]]}, projection=[a1, a2], has_header=false",
             "  CoalesceBatchesExec: target_batch_size=8192",
             "    RepartitionExec: partitioning=Hash([a2@1], 8), input_partitions=8",
-            "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+            "      OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1",
             // "     CsvExec: file_groups={1 group: [[tempdir/right.csv]]}, projection=[a1, a2], has_header=false"
         ]
     };

--- a/datafusion/expr/src/logical_plan/display.rs
+++ b/datafusion/expr/src/logical_plan/display.rs
@@ -516,6 +516,13 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
                         "Partition Count": n
                     })
                 }
+                Partitioning::OnDemand(n) => {
+                    json!({
+                        "Node Type": "Repartition",
+                        "Partitioning Scheme": "OnDemand",
+                        "Partition Count": n
+                    })
+                }
                 Partitioning::Hash(expr, n) => {
                     let hash_expr: Vec<String> =
                         expr.iter().map(|e| format!("{e}")).collect();

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -55,6 +55,7 @@ use datafusion_common::{
     UnnestOptions,
 };
 use indexmap::IndexSet;
+use sqlparser::ast::Partition;
 
 // backwards compatibility
 use crate::display::PgJsonVisitor;
@@ -827,15 +828,7 @@ impl LogicalPlan {
                 partitioning_scheme,
                 ..
             }) => match partitioning_scheme {
-                Partitioning::RoundRobinBatch(n) => {
-                    self.assert_no_expressions(expr)?;
-                    let input = self.only_input(inputs)?;
-                    Ok(LogicalPlan::Repartition(Repartition {
-                        partitioning_scheme: Partitioning::RoundRobinBatch(*n),
-                        input: Arc::new(input),
-                    }))
-                }
-                Partitioning::OnDemand(n) => {
+                Partitioning::RoundRobinBatch(n) | Partitioning::OnDemand(n) => {
                     self.assert_no_expressions(expr)?;
                     let input = self.only_input(inputs)?;
                     Ok(LogicalPlan::Repartition(Repartition {

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -835,6 +835,14 @@ impl LogicalPlan {
                         input: Arc::new(input),
                     }))
                 }
+                Partitioning::OnDemand(n) => {
+                    self.assert_no_expressions(expr)?;
+                    let input = self.only_input(inputs)?;
+                    Ok(LogicalPlan::Repartition(Repartition {
+                        partitioning_scheme: Partitioning::OnDemand(*n),
+                        input: Arc::new(input),
+                    }))
+                }
                 Partitioning::Hash(_, n) => {
                     let input = self.only_input(inputs)?;
                     Ok(LogicalPlan::Repartition(Repartition {
@@ -1912,6 +1920,9 @@ impl LogicalPlan {
                     }) => match partitioning_scheme {
                         Partitioning::RoundRobinBatch(n) => {
                             write!(f, "Repartition: RoundRobinBatch partition_count={n}")
+                        }
+                        Partitioning::OnDemand(n) => {
+                            write!(f, "Repartition: OnDemand partition_count={n}")
                         }
                         Partitioning::Hash(expr, n) => {
                             let hash_expr: Vec<String> =
@@ -3391,6 +3402,7 @@ pub enum Partitioning {
     Hash(Vec<Expr>, usize),
     /// The DISTRIBUTE BY clause is used to repartition the data based on the input expressions
     DistributeBy(Vec<Expr>),
+    OnDemand(usize),
 }
 
 /// Represent the unnesting operation on a list column, such as the recursion depth and

--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -415,7 +415,9 @@ impl LogicalPlan {
                 Partitioning::Hash(expr, _) | Partitioning::DistributeBy(expr) => {
                     expr.apply_elements(f)
                 }
-                Partitioning::RoundRobinBatch(_) => Ok(TreeNodeRecursion::Continue),
+                Partitioning::RoundRobinBatch(_) | Partitioning::OnDemand(_) => {
+                    Ok(TreeNodeRecursion::Continue)
+                }
             },
             LogicalPlan::Window(Window { window_expr, .. }) => {
                 window_expr.apply_elements(f)
@@ -527,7 +529,9 @@ impl LogicalPlan {
                 Partitioning::DistributeBy(expr) => expr
                     .map_elements(f)?
                     .update_data(Partitioning::DistributeBy),
-                Partitioning::RoundRobinBatch(_) => Transformed::no(partitioning_scheme),
+                Partitioning::RoundRobinBatch(_) | Partitioning::OnDemand(_) => {
+                    Transformed::no(partitioning_scheme)
+                }
             }
             .update_data(|partitioning_scheme| {
                 LogicalPlan::Repartition(Repartition {

--- a/datafusion/physical-expr/src/partitioning.rs
+++ b/datafusion/physical-expr/src/partitioning.rs
@@ -119,6 +119,8 @@ pub enum Partitioning {
     Hash(Vec<Arc<dyn PhysicalExpr>>, usize),
     /// Unknown partitioning scheme with a known number of partitions
     UnknownPartitioning(usize),
+    /// On Demand partitioning, where the partitioning is determined at runtime
+    OnDemand(usize),
 }
 
 impl Display for Partitioning {
@@ -136,6 +138,7 @@ impl Display for Partitioning {
             Partitioning::UnknownPartitioning(size) => {
                 write!(f, "UnknownPartitioning({size})")
             }
+            Partitioning::OnDemand(size) => write!(f, "OnDemand({size})"),
         }
     }
 }
@@ -144,7 +147,7 @@ impl Partitioning {
     pub fn partition_count(&self) -> usize {
         use Partitioning::*;
         match self {
-            RoundRobinBatch(n) | Hash(_, n) | UnknownPartitioning(n) => *n,
+            RoundRobinBatch(n) | Hash(_, n) | UnknownPartitioning(n) | OnDemand(n) => *n,
         }
     }
 

--- a/datafusion/physical-expr/src/partitioning.rs
+++ b/datafusion/physical-expr/src/partitioning.rs
@@ -235,6 +235,11 @@ impl PartialEq for Partitioning {
             {
                 true
             }
+            (Partitioning::OnDemand(count1), Partitioning::OnDemand(count2))
+                if count1 == count2 =>
+            {
+                true
+            }
             _ => false,
         }
     }
@@ -314,7 +319,8 @@ mod tests {
 
         let single_partition = Partitioning::UnknownPartitioning(1);
         let unspecified_partition = Partitioning::UnknownPartitioning(10);
-        let round_robin_partition = Partitioning::RoundRobinBatch(10);
+        // let round_robin_partition = Partitioning::RoundRobinBatch(10);
+        let round_robin_partition = Partitioning::OnDemand(10);
         let hash_partition1 = Partitioning::Hash(partition_exprs1, 10);
         let hash_partition2 = Partitioning::Hash(partition_exprs2, 10);
         let eq_properties = EquivalenceProperties::new(schema);

--- a/datafusion/physical-optimizer/src/coalesce_batches.rs
+++ b/datafusion/physical-optimizer/src/coalesce_batches.rs
@@ -26,8 +26,11 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_physical_expr::Partitioning;
 use datafusion_physical_plan::{
-    coalesce_batches::CoalesceBatchesExec, filter::FilterExec, joins::HashJoinExec,
-    repartition::RepartitionExec, ExecutionPlan,
+    coalesce_batches::CoalesceBatchesExec,
+    filter::FilterExec,
+    joins::HashJoinExec,
+    repartition::{on_demand_repartition::OnDemandRepartitionExec, RepartitionExec},
+    ExecutionPlan,
 };
 
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
@@ -70,8 +73,7 @@ impl PhysicalOptimizerRule for CoalesceBatches {
                             repart_exec.partitioning().clone(),
                             Partitioning::RoundRobinBatch(_)
                         )
-                    })
-                    .unwrap_or(false);
+                    }).unwrap_or(false);
             if wrap_in_coalesce {
                 Ok(Transformed::yes(Arc::new(CoalesceBatchesExec::new(
                     plan,

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -61,6 +61,7 @@ indexmap = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }
 log = { workspace = true }
 once_cell = "1.18.0"
+async-channel = "2.3.1"
 parking_lot = { workspace = true }
 pin-project-lite = "^0.2.7"
 rand = { workspace = true }

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -46,6 +46,7 @@ pub use crate::display::{DefaultDisplay, DisplayAs, DisplayFormatType, VerboseDi
 pub use crate::metrics::Metric;
 use crate::metrics::MetricsSet;
 pub use crate::ordering::InputOrderMode;
+use crate::repartition::on_demand_repartition::OnDemandRepartitionExec;
 use crate::repartition::RepartitionExec;
 use crate::sorts::sort_preserving_merge::SortPreservingMergeExec;
 pub use crate::stream::EmptyRecordBatchStream;
@@ -668,6 +669,13 @@ pub fn need_data_exchange(plan: Arc<dyn ExecutionPlan>) -> bool {
         !matches!(
             repartition.properties().output_partitioning(),
             Partitioning::RoundRobinBatch(_)
+        )
+    } else if let Some(repartition) =
+        plan.as_any().downcast_ref::<OnDemandRepartitionExec>()
+    {
+        !matches!(
+            repartition.properties().output_partitioning(),
+            Partitioning::OnDemand(_)
         )
     } else if let Some(coalesce) = plan.as_any().downcast_ref::<CoalescePartitionsExec>()
     {

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -851,6 +851,7 @@ impl<T: BatchTransformer + Unpin + Send> RecordBatchStream for NestedLoopJoinStr
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use crate::repartition::on_demand_repartition::OnDemandRepartitionExec;
     use crate::{
         common, expressions::Column, memory::MemoryExec, repartition::RepartitionExec,
         test::build_table_i32,
@@ -986,9 +987,14 @@ pub(crate) mod tests {
         let partition_count = 4;
 
         // Redistributing right input
-        let right = Arc::new(RepartitionExec::try_new(
+        // TODO: replaced with OnDemandRepartitionExec
+        // let right = Arc::new(RepartitionExec::try_new(
+        //     right,
+        //     Partitioning::RoundRobinBatch(partition_count),
+        // )?) as Arc<dyn ExecutionPlan>;
+        let right = Arc::new(OnDemandRepartitionExec::try_new(
             right,
-            Partitioning::RoundRobinBatch(partition_count),
+            Partitioning::OnDemand(partition_count),
         )?) as Arc<dyn ExecutionPlan>;
 
         // Use the required distribution for nested loop join to test partition data

--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -395,9 +395,14 @@ impl LazyMemoryExec {
         schema: SchemaRef,
         generators: Vec<Arc<RwLock<dyn LazyBatchGenerator>>>,
     ) -> Result<Self> {
+        // let cache = PlanProperties::new(
+        //     EquivalenceProperties::new(Arc::clone(&schema)),
+        //     Partitioning::RoundRobinBatch(generators.len()),
+        //     ExecutionMode::Bounded,
+        // );
         let cache = PlanProperties::new(
             EquivalenceProperties::new(Arc::clone(&schema)),
-            Partitioning::RoundRobinBatch(generators.len()),
+            Partitioning::OnDemand(generators.len()),
             ExecutionMode::Bounded,
         );
         Ok(Self {

--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -17,6 +17,7 @@
 
 //! Execution plan for reading in-memory batches of data
 
+use log::debug;
 use parking_lot::RwLock;
 use std::any::Any;
 use std::fmt;
@@ -338,6 +339,8 @@ impl Stream for MemoryStream {
         mut self: std::pin::Pin<&mut Self>,
         _: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
+        // TODO: To be removed
+        debug!("Memory Stream poll");
         Poll::Ready(if self.index < self.data.len() {
             self.index += 1;
             let batch = &self.data[self.index - 1];
@@ -350,6 +353,8 @@ impl Stream for MemoryStream {
 
             Some(Ok(batch))
         } else {
+            // TODO: To be removed
+            debug!("Memory stream exhausted!");
             None
         })
     }

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -54,7 +54,7 @@ use datafusion_physical_expr_common::sort_expr::LexOrdering;
 
 use datafusion_common::HashMap;
 use futures::stream::Stream;
-use futures::{FutureExt, StreamExt, TryStreamExt};
+use futures::{ready, FutureExt, StreamExt, TryStreamExt};
 use log::trace;
 use on_demand_repartition::OnDemandRepartitionExec;
 use parking_lot::Mutex;
@@ -1065,8 +1065,8 @@ impl Stream for RepartitionStream {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         loop {
-            match self.input.recv().poll_unpin(cx) {
-                Poll::Ready(Some(Some(v))) => {
+            match ready!(self.input.recv().poll_unpin(cx)) {
+                Some(Some(v)) => {
                     if let Ok(batch) = &v {
                         self.reservation
                             .lock()
@@ -1075,7 +1075,7 @@ impl Stream for RepartitionStream {
 
                     return Poll::Ready(Some(v));
                 }
-                Poll::Ready(Some(None)) => {
+                Some(None) => {
                     self.num_input_partitions_processed += 1;
 
                     if self.num_input_partitions == self.num_input_partitions_processed {
@@ -1086,11 +1086,8 @@ impl Stream for RepartitionStream {
                         continue;
                     }
                 }
-                Poll::Ready(None) => {
+                None => {
                     return Poll::Ready(None);
-                }
-                Poll::Pending => {
-                    return Poll::Pending;
                 }
             }
         }
@@ -1127,21 +1124,21 @@ impl Stream for PerPartitionStream {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        match self.receiver.recv().poll_unpin(cx) {
-            Poll::Ready(Some(Some(v))) => {
+        match ready!(self.receiver.recv().poll_unpin(cx)) {
+            Some(Some(v)) => {
                 if let Ok(batch) = &v {
                     self.reservation
                         .lock()
                         .shrink(batch.get_array_memory_size());
                 }
+
                 Poll::Ready(Some(v))
             }
-            Poll::Ready(Some(None)) => {
+            Some(None) => {
                 // Input partition has finished sending batches
                 Poll::Ready(None)
             }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            None => Poll::Ready(None),
         }
     }
 }

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -58,7 +58,7 @@ use log::trace;
 use parking_lot::Mutex;
 
 mod distributor_channels;
-mod on_demand_repartition;
+pub mod on_demand_repartition;
 
 type MaybeBatch = Option<Result<RecordBatch>>;
 type InputPartitionsToCurrentPartitionSender = Vec<DistributionSender<MaybeBatch>>;

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -768,18 +768,6 @@ impl ExecutionPlan for RepartitionExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        // TODO: make sure that this is only called for hash partitioning
-        // match self.partitioning() {
-        //     Partitioning::Hash(_, _) => {}
-        //     _ => {
-        //         panic!(
-        //             "RepartitionExec::execute should never be called directly. \
-        //         Partition type: {:?}",
-        //             self.partitioning()
-        //         );
-        //     }
-        // }
-
         trace!(
             "Start {}::execute for partition: {}",
             self.name(),

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -1692,18 +1692,12 @@ mod tests {
         )
         .unwrap()
     }
-}
 
-#[cfg(test)]
-mod test {
-    use arrow_schema::{DataType, Field, Schema, SortOptions};
+    use arrow_schema::SortOptions;
 
-    use crate::memory::MemoryExec;
+    use crate::coalesce_partitions::CoalescePartitionsExec;
     use crate::union::UnionExec;
-    use datafusion_physical_expr::expressions::col;
     use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
-
-    use super::*;
 
     /// Asserts that the plan is as expected
     ///
@@ -1770,6 +1764,36 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_coalesce_partition() -> Result<()> {
+        let schema = test_schema();
+        let partition = create_vec_batches(2);
+        let partitions = vec![partition.clone()];
+        let input = Arc::new(
+            MemoryExec::try_new(&partitions, Arc::clone(&schema), None).unwrap(),
+        );
+        let exec =
+            OnDemandRepartitionExec::try_new(input, Partitioning::RoundRobinBatch(2)).unwrap();
+
+        let coalesce_exec =
+            CoalescePartitionsExec::new(Arc::new(exec) as Arc<dyn ExecutionPlan>);
+
+        // CoalescePartitionExec should not change the plan
+        let expected_plan = [
+            "CoalescePartitionsExec",
+            "  OnDemandRepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1",
+            "    MemoryExec: partitions=1, partition_sizes=[2]",
+        ];
+        assert_plan!(expected_plan, coalesce_exec.clone());
+
+        // execute the plan
+        let task_ctx = Arc::new(TaskContext::default());
+        let stream = coalesce_exec.execute(0, task_ctx)?;
+        let batches = crate::common::collect(stream).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_preserve_order_input_not_sorted() -> Result<()> {
         let schema = test_schema();
         let source1 = memory_exec(&schema);
@@ -1792,9 +1816,6 @@ mod test {
         Ok(())
     }
 
-    fn test_schema() -> Arc<Schema> {
-        Arc::new(Schema::new(vec![Field::new("c0", DataType::UInt32, false)]))
-    }
 
     fn sort_exprs(schema: &Schema) -> LexOrdering {
         let options = SortOptions::default();

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -43,6 +43,7 @@ use arrow::compute::take_arrays;
 use arrow::datatypes::{SchemaRef, UInt32Type};
 use arrow::record_batch::RecordBatch;
 use arrow_array::{PrimitiveArray, RecordBatchOptions};
+use async_channel::Receiver;
 use datafusion_common::utils::transpose;
 use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_common_runtime::SpawnedTask;
@@ -55,6 +56,7 @@ use datafusion_common::HashMap;
 use futures::stream::Stream;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use log::trace;
+use on_demand_repartition::OnDemandRepartitionExec;
 use parking_lot::Mutex;
 
 mod distributor_channels;
@@ -63,6 +65,50 @@ pub mod on_demand_repartition;
 type MaybeBatch = Option<Result<RecordBatch>>;
 type InputPartitionsToCurrentPartitionSender = Vec<DistributionSender<MaybeBatch>>;
 type InputPartitionsToCurrentPartitionReceiver = Vec<DistributionReceiver<MaybeBatch>>;
+
+struct RepartitionExecStateBuilder {
+    /// Whether to enable pull based execution.
+    enable_pull_based: bool,
+    partition_receiver: Option<Receiver<usize>>,
+}
+
+impl RepartitionExecStateBuilder {
+    fn new() -> Self {
+        Self {
+            enable_pull_based: false,
+            partition_receiver: None,
+        }
+    }
+    fn enable_pull_based(mut self, enable_pull_based: bool) -> Self {
+        self.enable_pull_based = enable_pull_based;
+        self
+    }
+    fn partition_receiver(mut self, partition_receiver: Receiver<usize>) -> Self {
+        self.partition_receiver = Some(partition_receiver);
+        self
+    }
+
+    fn build(
+        &self,
+        input: Arc<dyn ExecutionPlan>,
+        partitioning: Partitioning,
+        metrics: ExecutionPlanMetricsSet,
+        preserve_order: bool,
+        name: String,
+        context: Arc<TaskContext>,
+    ) -> RepartitionExecState {
+        RepartitionExecState::new(
+            input,
+            partitioning,
+            metrics,
+            preserve_order,
+            name,
+            context,
+            self.enable_pull_based,
+            self.partition_receiver.clone(),
+        )
+    }
+}
 
 /// Inner state of [`RepartitionExec`].
 #[derive(Debug)]
@@ -82,6 +128,63 @@ struct RepartitionExecState {
     abort_helper: Arc<Vec<SpawnedTask<()>>>,
 }
 
+/// create channels for sending batches from input partitions to output partitions.
+fn create_repartition_channels(
+    preserve_order: bool,
+    num_input_partitions: usize,
+    num_output_partitions: usize,
+) -> (
+    Vec<InputPartitionsToCurrentPartitionSender>,
+    Vec<InputPartitionsToCurrentPartitionReceiver>,
+) {
+    if preserve_order {
+        let (txs, rxs) =
+            partition_aware_channels(num_input_partitions, num_output_partitions);
+        // Take transpose of senders and receivers. `state.channels` keeps track of entries per output partition
+        let txs = transpose(txs);
+        let rxs = transpose(rxs);
+        (txs, rxs)
+    } else {
+        // create one channel per *output* partition
+        // note we use a custom channel that ensures there is always data for each receiver
+        // but limits the amount of buffering if required.
+        let (txs, rxs) = channels(num_output_partitions);
+        // Clone sender for each input partitions
+        let txs = txs
+            .into_iter()
+            .map(|item| vec![item; num_input_partitions])
+            .collect::<Vec<_>>();
+        let rxs = rxs.into_iter().map(|item| vec![item]).collect::<Vec<_>>();
+        (txs, rxs)
+    }
+}
+
+/// Create a hashmap of channels for sending batches from input partitions to output partitions.
+fn create_partition_channels_hashmap(
+    txs: Vec<InputPartitionsToCurrentPartitionSender>,
+    rxs: Vec<InputPartitionsToCurrentPartitionReceiver>,
+    name: String,
+    context: Arc<TaskContext>,
+) -> HashMap<
+    usize,
+    (
+        InputPartitionsToCurrentPartitionSender,
+        InputPartitionsToCurrentPartitionReceiver,
+        SharedMemoryReservation,
+    ),
+> {
+    let mut channels = HashMap::with_capacity(txs.len());
+
+    for (partition, (tx, rx)) in txs.into_iter().zip(rxs).enumerate() {
+        let reservation = Arc::new(Mutex::new(
+            MemoryConsumer::new(format!("{}[{partition}]", name))
+                .register(context.memory_pool()),
+        ));
+        channels.insert(partition, (tx, rx, reservation));
+    }
+
+    channels
+}
 impl RepartitionExecState {
     fn new(
         input: Arc<dyn ExecutionPlan>,
@@ -90,39 +193,20 @@ impl RepartitionExecState {
         preserve_order: bool,
         name: String,
         context: Arc<TaskContext>,
+        enable_pull_based: bool,
+        partition_receiver: Option<Receiver<usize>>,
     ) -> Self {
         let num_input_partitions = input.output_partitioning().partition_count();
         let num_output_partitions = partitioning.partition_count();
 
-        let (txs, rxs) = if preserve_order {
-            let (txs, rxs) =
-                partition_aware_channels(num_input_partitions, num_output_partitions);
-            // Take transpose of senders and receivers. `state.channels` keeps track of entries per output partition
-            let txs = transpose(txs);
-            let rxs = transpose(rxs);
-            (txs, rxs)
-        } else {
-            // create one channel per *output* partition
-            // note we use a custom channel that ensures there is always data for each receiver
-            // but limits the amount of buffering if required.
-            let (txs, rxs) = channels(num_output_partitions);
-            // Clone sender for each input partitions
-            let txs = txs
-                .into_iter()
-                .map(|item| vec![item; num_input_partitions])
-                .collect::<Vec<_>>();
-            let rxs = rxs.into_iter().map(|item| vec![item]).collect::<Vec<_>>();
-            (txs, rxs)
-        };
+        let (txs, rxs) = create_repartition_channels(
+            preserve_order,
+            num_input_partitions,
+            num_output_partitions,
+        );
 
-        let mut channels = HashMap::with_capacity(txs.len());
-        for (partition, (tx, rx)) in txs.into_iter().zip(rxs).enumerate() {
-            let reservation = Arc::new(Mutex::new(
-                MemoryConsumer::new(format!("{}[{partition}]", name))
-                    .register(context.memory_pool()),
-            ));
-            channels.insert(partition, (tx, rx, reservation));
-        }
+        let channels =
+            create_partition_channels_hashmap(txs, rxs, name, Arc::clone(&context));
 
         // launch one async task per *input* partition
         let mut spawned_tasks = Vec::with_capacity(num_input_partitions);
@@ -136,23 +220,45 @@ impl RepartitionExecState {
 
             let r_metrics = RepartitionMetrics::new(i, num_output_partitions, &metrics);
 
-            let input_task = SpawnedTask::spawn(RepartitionExec::pull_from_input(
-                Arc::clone(&input),
-                i,
-                txs.clone(),
-                partitioning.clone(),
-                r_metrics,
-                Arc::clone(&context),
-            ));
+            let input_task = if enable_pull_based {
+                SpawnedTask::spawn(OnDemandRepartitionExec::pull_from_input(
+                    Arc::clone(&input),
+                    i,
+                    txs.clone(),
+                    partitioning.clone(),
+                    partition_receiver.clone().unwrap(),
+                    r_metrics,
+                    Arc::clone(&context),
+                ))
+            } else {
+                SpawnedTask::spawn(RepartitionExec::pull_from_input(
+                    Arc::clone(&input),
+                    i,
+                    txs.clone(),
+                    partitioning.clone(),
+                    r_metrics,
+                    Arc::clone(&context),
+                ))
+            };
 
             // In a separate task, wait for each input to be done
             // (and pass along any errors, including panic!s)
-            let wait_for_task = SpawnedTask::spawn(RepartitionExec::wait_for_task(
-                input_task,
-                txs.into_iter()
-                    .map(|(partition, (tx, _reservation))| (partition, tx))
-                    .collect(),
-            ));
+
+            let wait_for_task = if enable_pull_based {
+                SpawnedTask::spawn(OnDemandRepartitionExec::wait_for_task(
+                    input_task,
+                    txs.into_iter()
+                        .map(|(partition, (tx, _reservation))| (partition, tx))
+                        .collect(),
+                ))
+            } else {
+                SpawnedTask::spawn(RepartitionExec::wait_for_task(
+                    input_task,
+                    txs.into_iter()
+                        .map(|(partition, (tx, _reservation))| (partition, tx))
+                        .collect(),
+                ))
+            };
             spawned_tasks.push(wait_for_task);
         }
 
@@ -343,6 +449,93 @@ impl BatchPartitioner {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct RepartitionExecBase {
+    /// Input execution plan
+    input: Arc<dyn ExecutionPlan>,
+    /// Execution metrics
+    metrics: ExecutionPlanMetricsSet,
+    /// Boolean flag to decide whether to preserve ordering. If true means
+    /// `SortPreservingRepartitionExec`, false means `RepartitionExec`.
+    preserve_order: bool,
+    /// Cache holding plan properties like equivalences, output partitioning etc.
+    cache: PlanProperties,
+    /// Inner state that is initialized when the first output stream is created.
+    state: LazyState,
+}
+
+impl RepartitionExecBase {
+    fn maintains_input_order_helper(
+        input: &Arc<dyn ExecutionPlan>,
+        preserve_order: bool,
+    ) -> Vec<bool> {
+        // We preserve ordering when repartition is order preserving variant or input partitioning is 1
+        vec![preserve_order || input.output_partitioning().partition_count() <= 1]
+    }
+
+    fn eq_properties_helper(
+        input: &Arc<dyn ExecutionPlan>,
+        preserve_order: bool,
+    ) -> EquivalenceProperties {
+        // Equivalence Properties
+        let mut eq_properties = input.equivalence_properties().clone();
+        // If the ordering is lost, reset the ordering equivalence class:
+        if !Self::maintains_input_order_helper(input, preserve_order)[0] {
+            eq_properties.clear_orderings();
+        }
+        // When there are more than one input partitions, they will be fused at the output.
+        // Therefore, remove per partition constants.
+        if input.output_partitioning().partition_count() > 1 {
+            eq_properties.clear_per_partition_constants();
+        }
+        eq_properties
+    }
+
+    /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.
+    fn compute_properties(
+        input: &Arc<dyn ExecutionPlan>,
+        partitioning: Partitioning,
+        preserve_order: bool,
+    ) -> PlanProperties {
+        // Equivalence Properties
+        let eq_properties = Self::eq_properties_helper(input, preserve_order);
+
+        PlanProperties::new(
+            eq_properties,          // Equivalence Properties
+            partitioning,           // Output Partitioning
+            input.execution_mode(), // Execution Mode
+        )
+    }
+
+    /// Specify if this reparititoning operation should preserve the order of
+    /// rows from its input when producing output. Preserving order is more
+    /// expensive at runtime, so should only be set if the output of this
+    /// operator can take advantage of it.
+    ///
+    /// If the input is not ordered, or has only one partition, this is a no op,
+    /// and the node remains a `RepartitionExec`.
+    fn with_preserve_order(mut self) -> Self {
+        self.preserve_order =
+                // If the input isn't ordered, there is no ordering to preserve
+                self.input.output_ordering().is_some() &&
+                // if there is only one input partition, merging is not required
+                // to maintain order
+                self.input.output_partitioning().partition_count() > 1;
+        let eq_properties = Self::eq_properties_helper(&self.input, self.preserve_order);
+        self.cache = self.cache.with_eq_properties(eq_properties);
+        self
+    }
+
+    /// Return the sort expressions that are used to merge
+    fn sort_exprs(&self) -> Option<&LexOrdering> {
+        if self.preserve_order {
+            self.input.output_ordering()
+        } else {
+            None
+        }
+    }
+}
+
 /// Maps `N` input partitions to `M` output partitions based on a
 /// [`Partitioning`] scheme.
 ///
@@ -412,21 +605,12 @@ impl BatchPartitioner {
 /// data across threads.
 #[derive(Debug, Clone)]
 pub struct RepartitionExec {
-    /// Input execution plan
-    input: Arc<dyn ExecutionPlan>,
-    /// Inner state that is initialized when the first output stream is created.
-    state: LazyState,
-    /// Execution metrics
-    metrics: ExecutionPlanMetricsSet,
-    /// Boolean flag to decide whether to preserve ordering. If true means
-    /// `SortPreservingRepartitionExec`, false means `RepartitionExec`.
-    preserve_order: bool,
-    /// Cache holding plan properties like equivalences, output partitioning etc.
-    cache: PlanProperties,
+    /// Common fields for all repartitioning executors
+    base: RepartitionExecBase,
 }
 
 #[derive(Debug, Clone)]
-struct RepartitionMetrics {
+pub(crate) struct RepartitionMetrics {
     /// Time in nanos to execute child operator and fetch batches
     fetch_time: metrics::Time,
     /// Repartitioning elapsed time in nanos
@@ -473,18 +657,30 @@ impl RepartitionMetrics {
 impl RepartitionExec {
     /// Input execution plan
     pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
-        &self.input
+        &self.base.input
     }
 
     /// Partitioning scheme to use
     pub fn partitioning(&self) -> &Partitioning {
-        &self.cache.partitioning
+        &self.base.cache.partitioning
     }
 
     /// Get preserve_order flag of the RepartitionExecutor
     /// `true` means `SortPreservingRepartitionExec`, `false` means `RepartitionExec`
     pub fn preserve_order(&self) -> bool {
-        self.preserve_order
+        self.base.preserve_order
+    }
+
+    /// Specify if this reparititoning operation should preserve the order of
+    /// rows from its input when producing output. Preserving order is more
+    /// expensive at runtime, so should only be set if the output of this
+    /// operator can take advantage of it.
+    ///
+    /// If the input is not ordered, or has only one partition, this is a no op,
+    /// and the node remains a `RepartitionExec`.
+    pub fn with_preserve_order(mut self) -> Self {
+        self.base = self.base.with_preserve_order();
+        self
     }
 
     /// Get name used to display this Exec
@@ -506,14 +702,14 @@ impl DisplayAs for RepartitionExec {
                     "{}: partitioning={}, input_partitions={}",
                     self.name(),
                     self.partitioning(),
-                    self.input.output_partitioning().partition_count()
+                    self.base.input.output_partitioning().partition_count()
                 )?;
 
-                if self.preserve_order {
+                if self.base.preserve_order {
                     write!(f, ", preserve_order=true")?;
                 }
 
-                if let Some(sort_exprs) = self.sort_exprs() {
+                if let Some(sort_exprs) = self.base.sort_exprs() {
                     write!(f, ", sort_exprs={}", sort_exprs.clone())?;
                 }
                 Ok(())
@@ -533,11 +729,11 @@ impl ExecutionPlan for RepartitionExec {
     }
 
     fn properties(&self) -> &PlanProperties {
-        &self.cache
+        &self.base.cache
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.input]
+        vec![&self.base.input]
     }
 
     fn with_new_children(
@@ -548,7 +744,7 @@ impl ExecutionPlan for RepartitionExec {
             children.swap_remove(0),
             self.partitioning().clone(),
         )?;
-        if self.preserve_order {
+        if self.base.preserve_order {
             repartition = repartition.with_preserve_order();
         }
         Ok(Arc::new(repartition))
@@ -559,7 +755,10 @@ impl ExecutionPlan for RepartitionExec {
     }
 
     fn maintains_input_order(&self) -> Vec<bool> {
-        Self::maintains_input_order_helper(self.input(), self.preserve_order)
+        RepartitionExecBase::maintains_input_order_helper(
+            self.input(),
+            self.base.preserve_order,
+        )
     }
 
     fn execute(
@@ -573,17 +772,17 @@ impl ExecutionPlan for RepartitionExec {
             partition
         );
 
-        let lazy_state = Arc::clone(&self.state);
-        let input = Arc::clone(&self.input);
+        let lazy_state = Arc::clone(&self.base.state);
+        let input = Arc::clone(&self.base.input);
         let partitioning = self.partitioning().clone();
-        let metrics = self.metrics.clone();
-        let preserve_order = self.preserve_order;
+        let metrics = self.base.metrics.clone();
+        let preserve_order = self.base.preserve_order;
         let name = self.name().to_owned();
         let schema = self.schema();
         let schema_captured = Arc::clone(&schema);
 
         // Get existing ordering to use for merging
-        let sort_exprs = self.sort_exprs().cloned().unwrap_or_default();
+        let sort_exprs = self.base.sort_exprs().cloned().unwrap_or_default();
 
         let stream = futures::stream::once(async move {
             let num_input_partitions = input.output_partitioning().partition_count();
@@ -594,9 +793,9 @@ impl ExecutionPlan for RepartitionExec {
             let context_captured = Arc::clone(&context);
             let state = lazy_state
                 .get_or_init(|| async move {
-                    Mutex::new(RepartitionExecState::new(
+                    Mutex::new(RepartitionExecStateBuilder::new().build(
                         input_captured,
-                        partitioning,
+                        partitioning.clone(),
                         metrics_captured,
                         preserve_order,
                         name_captured,
@@ -673,11 +872,11 @@ impl ExecutionPlan for RepartitionExec {
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
-        Some(self.metrics.clone_inner())
+        Some(self.base.metrics.clone_inner())
     }
 
     fn statistics(&self) -> Result<Statistics> {
-        self.input.statistics()
+        self.base.input.statistics()
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
@@ -694,85 +893,20 @@ impl RepartitionExec {
         partitioning: Partitioning,
     ) -> Result<Self> {
         let preserve_order = false;
-        let cache =
-            Self::compute_properties(&input, partitioning.clone(), preserve_order);
-        Ok(RepartitionExec {
-            input,
-            state: Default::default(),
-            metrics: ExecutionPlanMetricsSet::new(),
+        let cache = RepartitionExecBase::compute_properties(
+            &input,
+            partitioning.clone(),
             preserve_order,
-            cache,
+        );
+        Ok(RepartitionExec {
+            base: RepartitionExecBase {
+                input,
+                state: Default::default(),
+                metrics: ExecutionPlanMetricsSet::new(),
+                preserve_order,
+                cache,
+            },
         })
-    }
-
-    fn maintains_input_order_helper(
-        input: &Arc<dyn ExecutionPlan>,
-        preserve_order: bool,
-    ) -> Vec<bool> {
-        // We preserve ordering when repartition is order preserving variant or input partitioning is 1
-        vec![preserve_order || input.output_partitioning().partition_count() <= 1]
-    }
-
-    fn eq_properties_helper(
-        input: &Arc<dyn ExecutionPlan>,
-        preserve_order: bool,
-    ) -> EquivalenceProperties {
-        // Equivalence Properties
-        let mut eq_properties = input.equivalence_properties().clone();
-        // If the ordering is lost, reset the ordering equivalence class:
-        if !Self::maintains_input_order_helper(input, preserve_order)[0] {
-            eq_properties.clear_orderings();
-        }
-        // When there are more than one input partitions, they will be fused at the output.
-        // Therefore, remove per partition constants.
-        if input.output_partitioning().partition_count() > 1 {
-            eq_properties.clear_per_partition_constants();
-        }
-        eq_properties
-    }
-
-    /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.
-    fn compute_properties(
-        input: &Arc<dyn ExecutionPlan>,
-        partitioning: Partitioning,
-        preserve_order: bool,
-    ) -> PlanProperties {
-        // Equivalence Properties
-        let eq_properties = Self::eq_properties_helper(input, preserve_order);
-
-        PlanProperties::new(
-            eq_properties,          // Equivalence Properties
-            partitioning,           // Output Partitioning
-            input.execution_mode(), // Execution Mode
-        )
-    }
-
-    /// Specify if this reparititoning operation should preserve the order of
-    /// rows from its input when producing output. Preserving order is more
-    /// expensive at runtime, so should only be set if the output of this
-    /// operator can take advantage of it.
-    ///
-    /// If the input is not ordered, or has only one partition, this is a no op,
-    /// and the node remains a `RepartitionExec`.
-    pub fn with_preserve_order(mut self) -> Self {
-        self.preserve_order =
-                // If the input isn't ordered, there is no ordering to preserve
-                self.input.output_ordering().is_some() &&
-                // if there is only one input partition, merging is not required
-                // to maintain order
-                self.input.output_partitioning().partition_count() > 1;
-        let eq_properties = Self::eq_properties_helper(&self.input, self.preserve_order);
-        self.cache = self.cache.with_eq_properties(eq_properties);
-        self
-    }
-
-    /// Return the sort expressions that are used to merge
-    fn sort_exprs(&self) -> Option<&LexOrdering> {
-        if self.preserve_order {
-            self.input.output_ordering()
-        } else {
-            None
-        }
     }
 
     /// Pulls data from the specified input plan, feeding it to the

--- a/datafusion/physical-plan/src/repartition/on_demand_repartition.rs
+++ b/datafusion/physical-plan/src/repartition/on_demand_repartition.rs
@@ -24,17 +24,20 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::{any::Any, vec};
 
-use super::common::SharedMemoryReservation;
 use super::metrics::{self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use super::{
-    DisplayAs, ExecutionPlanProperties, RecordBatchStream, SendableRecordBatchStream,
+    BatchPartitioner, DisplayAs, ExecutionPlanProperties,
+    InputPartitionsToCurrentPartitionReceiver, InputPartitionsToCurrentPartitionSender,
+    MaybeBatch, RecordBatchStream, RepartitionMetrics, SendableRecordBatchStream,
 };
+use crate::common::SharedMemoryReservation;
 use crate::execution_plan::CardinalityEffect;
 use crate::hash_utils::create_hashes;
 use crate::metrics::BaselineMetrics;
 use crate::repartition::distributor_channels::{
     channels, partition_aware_channels, DistributionReceiver, DistributionSender,
 };
+use crate::repartition::PerPartitionStream;
 use crate::sorts::streaming_merge::StreamingMergeBuilder;
 use crate::stream::RecordBatchStreamAdapter;
 use crate::{DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, Statistics};
@@ -57,17 +60,9 @@ use futures::{FutureExt, StreamExt, TryStreamExt};
 use log::trace;
 use parking_lot::Mutex;
 
-mod distributor_channels;
-mod on_demand_repartition;
-
-
-type MaybeBatch = Option<Result<RecordBatch>>;
-type InputPartitionsToCurrentPartitionSender = Vec<DistributionSender<MaybeBatch>>;
-type InputPartitionsToCurrentPartitionReceiver = Vec<DistributionReceiver<MaybeBatch>>;
-
 /// Inner state of [`RepartitionExec`].
 #[derive(Debug)]
-struct RepartitionExecState {
+struct OnDemandRepartitionExecState {
     /// Channels for sending batches from input partitions to output partitions.
     /// Key is the partition number.
     channels: HashMap<
@@ -83,7 +78,7 @@ struct RepartitionExecState {
     abort_helper: Arc<Vec<SpawnedTask<()>>>,
 }
 
-impl RepartitionExecState {
+impl OnDemandRepartitionExecState {
     fn new(
         input: Arc<dyn ExecutionPlan>,
         partitioning: Partitioning,
@@ -137,23 +132,25 @@ impl RepartitionExecState {
 
             let r_metrics = RepartitionMetrics::new(i, num_output_partitions, &metrics);
 
-            let input_task = SpawnedTask::spawn(RepartitionExec::pull_from_input(
-                Arc::clone(&input),
-                i,
-                txs.clone(),
-                partitioning.clone(),
-                r_metrics,
-                Arc::clone(&context),
-            ));
+            let input_task =
+                SpawnedTask::spawn(OnDemandRepartitionExec::pull_from_input(
+                    Arc::clone(&input),
+                    i,
+                    txs.clone(),
+                    partitioning.clone(),
+                    r_metrics,
+                    Arc::clone(&context),
+                ));
 
             // In a separate task, wait for each input to be done
             // (and pass along any errors, including panic!s)
-            let wait_for_task = SpawnedTask::spawn(RepartitionExec::wait_for_task(
-                input_task,
-                txs.into_iter()
-                    .map(|(partition, (tx, _reservation))| (partition, tx))
-                    .collect(),
-            ));
+            let wait_for_task =
+                SpawnedTask::spawn(OnDemandRepartitionExec::wait_for_task(
+                    input_task,
+                    txs.into_iter()
+                        .map(|(partition, (tx, _reservation))| (partition, tx))
+                        .collect(),
+                ));
             spawned_tasks.push(wait_for_task);
         }
 
@@ -176,233 +173,10 @@ impl RepartitionExecState {
 ///
 /// Uses a parking_lot `Mutex` to control other accesses as they are very short duration
 ///  (e.g. removing channels on completion) where the overhead of `await` is not warranted.
-type LazyState = Arc<tokio::sync::OnceCell<Mutex<RepartitionExecState>>>;
+type LazyState = Arc<tokio::sync::OnceCell<Mutex<OnDemandRepartitionExecState>>>;
 
-/// A utility that can be used to partition batches based on [`Partitioning`]
-pub struct BatchPartitioner {
-    state: BatchPartitionerState,
-    timer: metrics::Time,
-}
-
-enum BatchPartitionerState {
-    Hash {
-        random_state: ahash::RandomState,
-        exprs: Vec<Arc<dyn PhysicalExpr>>,
-        num_partitions: usize,
-        hash_buffer: Vec<u64>,
-    },
-    RoundRobin {
-        num_partitions: usize,
-        next_idx: usize,
-    },
-}
-
-impl BatchPartitioner {
-    /// Create a new [`BatchPartitioner`] with the provided [`Partitioning`]
-    ///
-    /// The time spent repartitioning will be recorded to `timer`
-    pub fn try_new(partitioning: Partitioning, timer: metrics::Time) -> Result<Self> {
-        let state = match partitioning {
-            Partitioning::RoundRobinBatch(num_partitions) => {
-                BatchPartitionerState::RoundRobin {
-                    num_partitions,
-                    next_idx: 0,
-                }
-            }
-            Partitioning::Hash(exprs, num_partitions) => BatchPartitionerState::Hash {
-                exprs,
-                num_partitions,
-                // Use fixed random hash
-                random_state: ahash::RandomState::with_seeds(0, 0, 0, 0),
-                hash_buffer: vec![],
-            },
-            other => return not_impl_err!("Unsupported repartitioning scheme {other:?}"),
-        };
-
-        Ok(Self { state, timer })
-    }
-
-    /// Partition the provided [`RecordBatch`] into one or more partitioned [`RecordBatch`]
-    /// based on the [`Partitioning`] specified on construction
-    ///
-    /// `f` will be called for each partitioned [`RecordBatch`] with the corresponding
-    /// partition index. Any error returned by `f` will be immediately returned by this
-    /// function without attempting to publish further [`RecordBatch`]
-    ///
-    /// The time spent repartitioning, not including time spent in `f` will be recorded
-    /// to the [`metrics::Time`] provided on construction
-    pub fn partition<F>(&mut self, batch: RecordBatch, mut f: F) -> Result<()>
-    where
-        F: FnMut(usize, RecordBatch) -> Result<()>,
-    {
-        self.partition_iter(batch)?.try_for_each(|res| match res {
-            Ok((partition, batch)) => f(partition, batch),
-            Err(e) => Err(e),
-        })
-    }
-
-    /// Actual implementation of [`partition`](Self::partition).
-    ///
-    /// The reason this was pulled out is that we need to have a variant of `partition` that works w/ sync functions,
-    /// and one that works w/ async. Using an iterator as an intermediate representation was the best way to achieve
-    /// this (so we don't need to clone the entire implementation).
-    fn partition_iter(
-        &mut self,
-        batch: RecordBatch,
-    ) -> Result<impl Iterator<Item = Result<(usize, RecordBatch)>> + Send + '_> {
-        let it: Box<dyn Iterator<Item = Result<(usize, RecordBatch)>> + Send> =
-            match &mut self.state {
-                BatchPartitionerState::RoundRobin {
-                    num_partitions,
-                    next_idx,
-                } => {
-                    let idx = *next_idx;
-                    *next_idx = (*next_idx + 1) % *num_partitions;
-                    Box::new(std::iter::once(Ok((idx, batch))))
-                }
-                BatchPartitionerState::Hash {
-                    random_state,
-                    exprs,
-                    num_partitions: partitions,
-                    hash_buffer,
-                } => {
-                    // Tracking time required for distributing indexes across output partitions
-                    let timer = self.timer.timer();
-
-                    let arrays = exprs
-                        .iter()
-                        .map(|expr| expr.evaluate(&batch)?.into_array(batch.num_rows()))
-                        .collect::<Result<Vec<_>>>()?;
-
-                    hash_buffer.clear();
-                    hash_buffer.resize(batch.num_rows(), 0);
-
-                    create_hashes(&arrays, random_state, hash_buffer)?;
-
-                    let mut indices: Vec<_> = (0..*partitions)
-                        .map(|_| Vec::with_capacity(batch.num_rows()))
-                        .collect();
-
-                    for (index, hash) in hash_buffer.iter().enumerate() {
-                        indices[(*hash % *partitions as u64) as usize].push(index as u32);
-                    }
-
-                    // Finished building index-arrays for output partitions
-                    timer.done();
-
-                    // Borrowing partitioner timer to prevent moving `self` to closure
-                    let partitioner_timer = &self.timer;
-                    let it = indices
-                        .into_iter()
-                        .enumerate()
-                        .filter_map(|(partition, indices)| {
-                            let indices: PrimitiveArray<UInt32Type> = indices.into();
-                            (!indices.is_empty()).then_some((partition, indices))
-                        })
-                        .map(move |(partition, indices)| {
-                            // Tracking time required for repartitioned batches construction
-                            let _timer = partitioner_timer.timer();
-
-                            // Produce batches based on indices
-                            let columns = take_arrays(batch.columns(), &indices, None)?;
-
-                            let mut options = RecordBatchOptions::new();
-                            options = options.with_row_count(Some(indices.len()));
-                            let batch = RecordBatch::try_new_with_options(
-                                batch.schema(),
-                                columns,
-                                &options,
-                            )
-                            .unwrap();
-
-                            Ok((partition, batch))
-                        });
-
-                    Box::new(it)
-                }
-            };
-
-        Ok(it)
-    }
-
-    // return the number of output partitions
-    fn num_partitions(&self) -> usize {
-        match self.state {
-            BatchPartitionerState::RoundRobin { num_partitions, .. } => num_partitions,
-            BatchPartitionerState::Hash { num_partitions, .. } => num_partitions,
-        }
-    }
-}
-
-/// Maps `N` input partitions to `M` output partitions based on a
-/// [`Partitioning`] scheme.
-///
-/// # Background
-///
-/// DataFusion, like most other commercial systems, with the
-/// notable exception of DuckDB, uses the "Exchange Operator" based
-/// approach to parallelism which works well in practice given
-/// sufficient care in implementation.
-///
-/// DataFusion's planner picks the target number of partitions and
-/// then `RepartionExec` redistributes [`RecordBatch`]es to that number
-/// of output partitions.
-///
-/// For example, given `target_partitions=3` (trying to use 3 cores)
-/// but scanning an input with 2 partitions, `RepartitionExec` can be
-/// used to get 3 even streams of `RecordBatch`es
-///
-///
-///```text
-///        ▲                  ▲                  ▲
-///        │                  │                  │
-///        │                  │                  │
-///        │                  │                  │
-///┌───────────────┐  ┌───────────────┐  ┌───────────────┐
-///│    GroupBy    │  │    GroupBy    │  │    GroupBy    │
-///│   (Partial)   │  │   (Partial)   │  │   (Partial)   │
-///└───────────────┘  └───────────────┘  └───────────────┘
-///        ▲                  ▲                  ▲
-///        └──────────────────┼──────────────────┘
-///                           │
-///              ┌─────────────────────────┐
-///              │     RepartitionExec     │
-///              │   (hash/round robin)    │
-///              └─────────────────────────┘
-///                         ▲   ▲
-///             ┌───────────┘   └───────────┐
-///             │                           │
-///             │                           │
-///        .─────────.                 .─────────.
-///     ,─'           '─.           ,─'           '─.
-///    ;      Input      :         ;      Input      :
-///    :   Partition 0   ;         :   Partition 1   ;
-///     ╲               ╱           ╲               ╱
-///      '─.         ,─'             '─.         ,─'
-///         `───────'                   `───────'
-///```
-///
-/// # Error Handling
-///
-/// If any of the input partitions return an error, the error is propagated to
-/// all output partitions and inputs are not polled again.
-///
-/// # Output Ordering
-///
-/// If more than one stream is being repartitioned, the output will be some
-/// arbitrary interleaving (and thus unordered) unless
-/// [`Self::with_preserve_order`] specifies otherwise.
-///
-/// # Footnote
-///
-/// The "Exchange Operator" was first described in the 1989 paper
-/// [Encapsulation of parallelism in the Volcano query processing
-/// system
-/// Paper](https://w6113.github.io/files/papers/volcanoparallelism-89.pdf)
-/// which uses the term "Exchange" for the concept of repartitioning
-/// data across threads.
 #[derive(Debug, Clone)]
-pub struct RepartitionExec {
+pub struct OnDemandRepartitionExec {
     /// Input execution plan
     input: Arc<dyn ExecutionPlan>,
     /// Inner state that is initialized when the first output stream is created.
@@ -416,52 +190,7 @@ pub struct RepartitionExec {
     cache: PlanProperties,
 }
 
-#[derive(Debug, Clone)]
-struct RepartitionMetrics {
-    /// Time in nanos to execute child operator and fetch batches
-    fetch_time: metrics::Time,
-    /// Repartitioning elapsed time in nanos
-    repartition_time: metrics::Time,
-    /// Time in nanos for sending resulting batches to channels.
-    ///
-    /// One metric per output partition.
-    send_time: Vec<metrics::Time>,
-}
-
-impl RepartitionMetrics {
-    pub fn new(
-        input_partition: usize,
-        num_output_partitions: usize,
-        metrics: &ExecutionPlanMetricsSet,
-    ) -> Self {
-        // Time in nanos to execute child operator and fetch batches
-        let fetch_time =
-            MetricBuilder::new(metrics).subset_time("fetch_time", input_partition);
-
-        // Time in nanos to perform repartitioning
-        let repartition_time =
-            MetricBuilder::new(metrics).subset_time("repartition_time", input_partition);
-
-        // Time in nanos for sending resulting batches to channels
-        let send_time = (0..num_output_partitions)
-            .map(|output_partition| {
-                let label =
-                    metrics::Label::new("outputPartition", output_partition.to_string());
-                MetricBuilder::new(metrics)
-                    .with_label(label)
-                    .subset_time("send_time", input_partition)
-            })
-            .collect();
-
-        Self {
-            fetch_time,
-            repartition_time,
-            send_time,
-        }
-    }
-}
-
-impl RepartitionExec {
+impl OnDemandRepartitionExec {
     /// Input execution plan
     pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
         &self.input
@@ -480,11 +209,11 @@ impl RepartitionExec {
 
     /// Get name used to display this Exec
     pub fn name(&self) -> &str {
-        "RepartitionExec"
+        "OnDemandRepartitionExec"
     }
 }
 
-impl DisplayAs for RepartitionExec {
+impl DisplayAs for OnDemandRepartitionExec {
     fn fmt_as(
         &self,
         t: DisplayFormatType,
@@ -513,9 +242,9 @@ impl DisplayAs for RepartitionExec {
     }
 }
 
-impl ExecutionPlan for RepartitionExec {
+impl ExecutionPlan for OnDemandRepartitionExec {
     fn name(&self) -> &'static str {
-        "RepartitionExec"
+        "OnDemandRepartitionExec"
     }
 
     /// Return a reference to Any that can be used for downcasting
@@ -535,7 +264,7 @@ impl ExecutionPlan for RepartitionExec {
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let mut repartition = RepartitionExec::try_new(
+        let mut repartition = OnDemandRepartitionExec::try_new(
             children.swap_remove(0),
             self.partitioning().clone(),
         )?;
@@ -585,7 +314,7 @@ impl ExecutionPlan for RepartitionExec {
             let context_captured = Arc::clone(&context);
             let state = lazy_state
                 .get_or_init(|| async move {
-                    Mutex::new(RepartitionExecState::new(
+                    Mutex::new(OnDemandRepartitionExecState::new(
                         input_captured,
                         partitioning,
                         metrics_captured,
@@ -648,7 +377,7 @@ impl ExecutionPlan for RepartitionExec {
                     .with_reservation(merge_reservation)
                     .build()
             } else {
-                Ok(Box::pin(RepartitionStream {
+                Ok(Box::pin(OnDemandRepartitionStream {
                     num_input_partitions,
                     num_input_partitions_processed: 0,
                     schema: input.schema(),
@@ -676,7 +405,7 @@ impl ExecutionPlan for RepartitionExec {
     }
 }
 
-impl RepartitionExec {
+impl OnDemandRepartitionExec {
     /// Create a new RepartitionExec, that produces output `partitioning`, and
     /// does not preserve the order of the input (see [`Self::with_preserve_order`]
     /// for more details)
@@ -687,7 +416,7 @@ impl RepartitionExec {
         let preserve_order = false;
         let cache =
             Self::compute_properties(&input, partitioning.clone(), preserve_order);
-        Ok(RepartitionExec {
+        Ok(OnDemandRepartitionExec {
             input,
             state: Default::default(),
             metrics: ExecutionPlanMetricsSet::new(),
@@ -894,7 +623,7 @@ impl RepartitionExec {
     }
 }
 
-struct RepartitionStream {
+struct OnDemandRepartitionStream {
     /// Number of input partitions that will be sending batches to this output channel
     num_input_partitions: usize,
 
@@ -914,7 +643,7 @@ struct RepartitionStream {
     reservation: SharedMemoryReservation,
 }
 
-impl Stream for RepartitionStream {
+impl Stream for OnDemandRepartitionStream {
     type Item = Result<RecordBatch>;
 
     fn poll_next(
@@ -954,56 +683,7 @@ impl Stream for RepartitionStream {
     }
 }
 
-impl RecordBatchStream for RepartitionStream {
-    /// Get the schema
-    fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
-    }
-}
-
-/// This struct converts a receiver to a stream.
-/// Receiver receives data on an SPSC channel.
-struct PerPartitionStream {
-    /// Schema wrapped by Arc
-    schema: SchemaRef,
-
-    /// channel containing the repartitioned batches
-    receiver: DistributionReceiver<MaybeBatch>,
-
-    /// Handle to ensure background tasks are killed when no longer needed.
-    _drop_helper: Arc<Vec<SpawnedTask<()>>>,
-
-    /// Memory reservation.
-    reservation: SharedMemoryReservation,
-}
-
-impl Stream for PerPartitionStream {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        match self.receiver.recv().poll_unpin(cx) {
-            Poll::Ready(Some(Some(v))) => {
-                if let Ok(batch) = &v {
-                    self.reservation
-                        .lock()
-                        .shrink(batch.get_array_memory_size());
-                }
-                Poll::Ready(Some(v))
-            }
-            Poll::Ready(Some(None)) => {
-                // Input partition has finished sending batches
-                Poll::Ready(None)
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl RecordBatchStream for PerPartitionStream {
+impl RecordBatchStream for OnDemandRepartitionStream {
     /// Get the schema
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
@@ -1012,7 +692,6 @@ impl RecordBatchStream for PerPartitionStream {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
 
     use super::*;
     use crate::{
@@ -1031,8 +710,6 @@ mod tests {
     use datafusion_common::cast::as_string_array;
     use datafusion_common::{arrow_datafusion_err, assert_batches_sorted_eq, exec_err};
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
-
-    use tokio::task::JoinSet;
 
     #[tokio::test]
     async fn one_to_many_round_robin() -> Result<()> {
@@ -1129,7 +806,7 @@ mod tests {
         let task_ctx = Arc::new(TaskContext::default());
         // create physical plan
         let exec = MemoryExec::try_new(&input_partitions, Arc::clone(schema), None)?;
-        let exec = RepartitionExec::try_new(Arc::new(exec), partitioning)?;
+        let exec = OnDemandRepartitionExec::try_new(Arc::new(exec), partitioning)?;
 
         // execute and collect results
         let mut output_partitions = vec![];
@@ -1143,32 +820,6 @@ mod tests {
             output_partitions.push(batches);
         }
         Ok(output_partitions)
-    }
-
-    #[tokio::test]
-    async fn many_to_many_round_robin_within_tokio_task() -> Result<()> {
-        let handle: SpawnedTask<Result<Vec<Vec<RecordBatch>>>> =
-            SpawnedTask::spawn(async move {
-                // define input partitions
-                let schema = test_schema();
-                let partition = create_vec_batches(50);
-                let partitions =
-                    vec![partition.clone(), partition.clone(), partition.clone()];
-
-                // repartition from 3 input to 5 output
-                repartition(&schema, partitions, Partitioning::RoundRobinBatch(5)).await
-            });
-
-        let output_partitions = handle.join().await.unwrap().unwrap();
-
-        assert_eq!(5, output_partitions.len());
-        assert_eq!(30, output_partitions[0].len());
-        assert_eq!(30, output_partitions[1].len());
-        assert_eq!(30, output_partitions[2].len());
-        assert_eq!(30, output_partitions[3].len());
-        assert_eq!(30, output_partitions[4].len());
-
-        Ok(())
     }
 
     #[tokio::test]
@@ -1187,7 +838,8 @@ mod tests {
         // but only after the plan is executed. The error should be
         // returned and no results produced
         let partitioning = Partitioning::UnknownPartitioning(1);
-        let exec = RepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
+        let exec =
+            OnDemandRepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
         let output_stream = exec.execute(0, task_ctx).unwrap();
 
         // Expect that an error is returned
@@ -1210,7 +862,8 @@ mod tests {
         let task_ctx = Arc::new(TaskContext::default());
         let input = ErrorExec::new();
         let partitioning = Partitioning::RoundRobinBatch(1);
-        let exec = RepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
+        let exec =
+            OnDemandRepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
 
         // Note: this should pass (the stream can be created) but the
         // error when the input is executed should get passed back
@@ -1243,7 +896,8 @@ mod tests {
         let schema = batch.schema();
         let input = MockExec::new(vec![Ok(batch), err], schema);
         let partitioning = Partitioning::RoundRobinBatch(1);
-        let exec = RepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
+        let exec =
+            OnDemandRepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
 
         // Note: this should pass (the stream can be created) but the
         // error when the input is executed should get passed back
@@ -1282,7 +936,8 @@ mod tests {
         let input = MockExec::new(vec![Ok(batch1), Ok(batch2)], schema);
         let partitioning = Partitioning::RoundRobinBatch(1);
 
-        let exec = RepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
+        let exec =
+            OnDemandRepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
 
         let expected = vec![
             "+------------------+",
@@ -1301,111 +956,6 @@ mod tests {
         let batches = crate::common::collect(output_stream).await.unwrap();
 
         assert_batches_sorted_eq!(&expected, &batches);
-    }
-
-    #[tokio::test]
-    async fn robin_repartition_with_dropping_output_stream() {
-        let task_ctx = Arc::new(TaskContext::default());
-        let partitioning = Partitioning::RoundRobinBatch(2);
-        // The barrier exec waits to be pinged
-        // requires the input to wait at least once)
-        let input = Arc::new(make_barrier_exec());
-
-        // partition into two output streams
-        let exec = RepartitionExec::try_new(
-            Arc::clone(&input) as Arc<dyn ExecutionPlan>,
-            partitioning,
-        )
-        .unwrap();
-
-        let output_stream0 = exec.execute(0, Arc::clone(&task_ctx)).unwrap();
-        let output_stream1 = exec.execute(1, Arc::clone(&task_ctx)).unwrap();
-
-        // now, purposely drop output stream 0
-        // *before* any outputs are produced
-        drop(output_stream0);
-
-        // Now, start sending input
-        let mut background_task = JoinSet::new();
-        background_task.spawn(async move {
-            input.wait().await;
-        });
-
-        // output stream 1 should *not* error and have one of the input batches
-        let batches = crate::common::collect(output_stream1).await.unwrap();
-
-        let expected = vec![
-            "+------------------+",
-            "| my_awesome_field |",
-            "+------------------+",
-            "| baz              |",
-            "| frob             |",
-            "| gaz              |",
-            "| grob             |",
-            "+------------------+",
-        ];
-
-        assert_batches_sorted_eq!(&expected, &batches);
-    }
-
-    #[tokio::test]
-    // As the hash results might be different on different platforms or
-    // with different compilers, we will compare the same execution with
-    // and without dropping the output stream.
-    async fn hash_repartition_with_dropping_output_stream() {
-        let task_ctx = Arc::new(TaskContext::default());
-        let partitioning = Partitioning::Hash(
-            vec![Arc::new(crate::expressions::Column::new(
-                "my_awesome_field",
-                0,
-            ))],
-            2,
-        );
-
-        // We first collect the results without dropping the output stream.
-        let input = Arc::new(make_barrier_exec());
-        let exec = RepartitionExec::try_new(
-            Arc::clone(&input) as Arc<dyn ExecutionPlan>,
-            partitioning.clone(),
-        )
-        .unwrap();
-        let output_stream1 = exec.execute(1, Arc::clone(&task_ctx)).unwrap();
-        let mut background_task = JoinSet::new();
-        background_task.spawn(async move {
-            input.wait().await;
-        });
-        let batches_without_drop = crate::common::collect(output_stream1).await.unwrap();
-
-        // run some checks on the result
-        let items_vec = str_batches_to_vec(&batches_without_drop);
-        let items_set: HashSet<&str> = items_vec.iter().copied().collect();
-        assert_eq!(items_vec.len(), items_set.len());
-        let source_str_set: HashSet<&str> =
-            ["foo", "bar", "frob", "baz", "goo", "gar", "grob", "gaz"]
-                .iter()
-                .copied()
-                .collect();
-        assert_eq!(items_set.difference(&source_str_set).count(), 0);
-
-        // Now do the same but dropping the stream before waiting for the barrier
-        let input = Arc::new(make_barrier_exec());
-        let exec = RepartitionExec::try_new(
-            Arc::clone(&input) as Arc<dyn ExecutionPlan>,
-            partitioning,
-        )
-        .unwrap();
-        let output_stream0 = exec.execute(0, Arc::clone(&task_ctx)).unwrap();
-        let output_stream1 = exec.execute(1, Arc::clone(&task_ctx)).unwrap();
-        // now, purposely drop output stream 0
-        // *before* any outputs are produced
-        drop(output_stream0);
-        let mut background_task = JoinSet::new();
-        background_task.spawn(async move {
-            input.wait().await;
-        });
-        let batches_with_drop = crate::common::collect(output_stream1).await.unwrap();
-
-        assert_eq!(batches_without_drop, batches_with_drop);
     }
 
     fn str_batches_to_vec(batches: &[RecordBatch]) -> Vec<&str> {
@@ -1464,7 +1014,7 @@ mod tests {
 
         let blocking_exec = Arc::new(BlockingExec::new(Arc::clone(&schema), 2));
         let refs = blocking_exec.refs();
-        let repartition_exec = Arc::new(RepartitionExec::try_new(
+        let repartition_exec = Arc::new(OnDemandRepartitionExec::try_new(
             blocking_exec,
             Partitioning::UnknownPartitioning(1),
         )?);
@@ -1476,29 +1026,6 @@ mod tests {
         drop(fut);
         assert_strong_count_converges_to_zero(refs).await;
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn hash_repartition_avoid_empty_batch() -> Result<()> {
-        let task_ctx = Arc::new(TaskContext::default());
-        let batch = RecordBatch::try_from_iter(vec![(
-            "a",
-            Arc::new(StringArray::from(vec!["foo"])) as ArrayRef,
-        )])
-        .unwrap();
-        let partitioning = Partitioning::Hash(
-            vec![Arc::new(crate::expressions::Column::new("a", 0))],
-            2,
-        );
-        let schema = batch.schema();
-        let input = MockExec::new(vec![Ok(batch)], schema);
-        let exec = RepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
-        let output_stream0 = exec.execute(0, Arc::clone(&task_ctx)).unwrap();
-        let batch0 = crate::common::collect(output_stream0).await.unwrap();
-        let output_stream1 = exec.execute(1, Arc::clone(&task_ctx)).unwrap();
-        let batch1 = crate::common::collect(output_stream1).await.unwrap();
-        assert!(batch0.is_empty() || batch1.is_empty());
         Ok(())
     }
 
@@ -1520,7 +1047,7 @@ mod tests {
 
         // create physical plan
         let exec = MemoryExec::try_new(&input_partitions, Arc::clone(&schema), None)?;
-        let exec = RepartitionExec::try_new(Arc::new(exec), partitioning)?;
+        let exec = OnDemandRepartitionExec::try_new(Arc::new(exec), partitioning)?;
 
         // pull partitions
         for i in 0..exec.partitioning().partition_count() {
@@ -1594,14 +1121,16 @@ mod test {
         let source2 = sorted_memory_exec(&schema, sort_exprs);
         // output has multiple partitions, and is sorted
         let union = UnionExec::new(vec![source1, source2]);
-        let exec =
-            RepartitionExec::try_new(Arc::new(union), Partitioning::RoundRobinBatch(10))
-                .unwrap()
-                .with_preserve_order();
+        let exec = OnDemandRepartitionExec::try_new(
+            Arc::new(union),
+            Partitioning::RoundRobinBatch(10),
+        )
+        .unwrap()
+        .with_preserve_order();
 
         // Repartition should preserve order
         let expected_plan = [
-            "RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=2, preserve_order=true, sort_exprs=c0@0 ASC",
+            "OnDemandRepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=2, preserve_order=true, sort_exprs=c0@0 ASC",
             "  UnionExec",
             "    MemoryExec: partitions=1, partition_sizes=[0], output_ordering=c0@0 ASC",
             "    MemoryExec: partitions=1, partition_sizes=[0], output_ordering=c0@0 ASC",
@@ -1616,13 +1145,14 @@ mod test {
         let sort_exprs = sort_exprs(&schema);
         let source = sorted_memory_exec(&schema, sort_exprs);
         // output is sorted, but has only a single partition, so no need to sort
-        let exec = RepartitionExec::try_new(source, Partitioning::RoundRobinBatch(10))
-            .unwrap()
-            .with_preserve_order();
+        let exec =
+            OnDemandRepartitionExec::try_new(source, Partitioning::RoundRobinBatch(10))
+                .unwrap()
+                .with_preserve_order();
 
         // Repartition should not preserve order
         let expected_plan = [
-            "RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1",
+            "OnDemandRepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1",
             "  MemoryExec: partitions=1, partition_sizes=[0], output_ordering=c0@0 ASC",
         ];
         assert_plan!(expected_plan, exec);
@@ -1636,14 +1166,16 @@ mod test {
         let source2 = memory_exec(&schema);
         // output has multiple partitions, but is not sorted
         let union = UnionExec::new(vec![source1, source2]);
-        let exec =
-            RepartitionExec::try_new(Arc::new(union), Partitioning::RoundRobinBatch(10))
-                .unwrap()
-                .with_preserve_order();
+        let exec = OnDemandRepartitionExec::try_new(
+            Arc::new(union),
+            Partitioning::RoundRobinBatch(10),
+        )
+        .unwrap()
+        .with_preserve_order();
 
         // Repartition should not preserve order, as there is no order to preserve
         let expected_plan = [
-            "RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=2",
+            "OnDemandRepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=2",
             "  UnionExec",
             "    MemoryExec: partitions=1, partition_sizes=[0]",
             "    MemoryExec: partitions=1, partition_sizes=[0]",

--- a/datafusion/physical-plan/src/repartition/on_demand_repartition.rs
+++ b/datafusion/physical-plan/src/repartition/on_demand_repartition.rs
@@ -806,7 +806,7 @@ mod tests {
     #[tokio::test]
     async fn many_to_many_on_demand_with_coalesce() -> Result<()> {
         let schema = test_schema();
-        let partition: Vec<RecordBatch> = create_vec_batches(1);
+        let partition: Vec<RecordBatch> = create_vec_batches(2);
         let partitions = vec![partition.clone(), partition.clone()];
         let input = Arc::new(
             MemoryExec::try_new(&partitions, Arc::clone(&schema), None).unwrap(),
@@ -820,7 +820,7 @@ mod tests {
         let expected_plan = [
             "CoalescePartitionsExec",
             "  OnDemandRepartitionExec: partitioning=OnDemand(3), input_partitions=2",
-            "    MemoryExec: partitions=2, partition_sizes=[1, 1]",
+            "    MemoryExec: partitions=2, partition_sizes=[2, 2]",
         ];
         assert_plan!(expected_plan, coalesce_exec.clone());
 
@@ -970,7 +970,7 @@ mod tests {
         let schema = batch1.schema();
         let expected_batches = vec![batch1.clone(), batch2.clone()];
         let input = MockExec::new(vec![Ok(batch1), Ok(batch2)], schema);
-        let partitioning = Partitioning::RoundRobinBatch(1);
+        let partitioning = Partitioning::OnDemand(1);
 
         let exec =
             OnDemandRepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
@@ -1143,7 +1143,7 @@ mod tests {
         let schema = test_schema();
         let partition = create_vec_batches(50);
         let input_partitions = vec![partition];
-        let partitioning = Partitioning::RoundRobinBatch(4);
+        let partitioning = Partitioning::OnDemand(4);
 
         // setup up context
         let runtime = RuntimeEnvBuilder::default()
@@ -1198,7 +1198,7 @@ mod tests {
         let union = UnionExec::new(vec![source1, source2]);
         let exec = OnDemandRepartitionExec::try_new(
             Arc::new(union),
-            Partitioning::RoundRobinBatch(10),
+            Partitioning::OnDemand(10),
         )
         .unwrap()
         .with_preserve_order();

--- a/datafusion/physical-plan/src/repartition/on_demand_repartition.rs
+++ b/datafusion/physical-plan/src/repartition/on_demand_repartition.rs
@@ -530,7 +530,7 @@ impl Stream for OnDemandPerPartitionStream {
                 "On Demand Repartition per partition poll {}, send partition number",
                 self.partition
             );
-            self.is_requested = true;
+            // self.is_requested = true;
         }
 
         match ready!(self.receiver.recv().poll_unpin(cx)) {
@@ -836,18 +836,34 @@ mod tests {
             "+----+",
             "| 1  |",
             "| 1  |",
+            "| 1  |",
+            "| 1  |",
+            "| 2  |",
+            "| 2  |",
             "| 2  |",
             "| 2  |",
             "| 3  |",
             "| 3  |",
+            "| 3  |",
+            "| 3  |",
+            "| 4  |",
+            "| 4  |",
             "| 4  |",
             "| 4  |",
             "| 5  |",
             "| 5  |",
+            "| 5  |",
+            "| 5  |",
+            "| 6  |",
+            "| 6  |",
             "| 6  |",
             "| 6  |",
             "| 7  |",
             "| 7  |",
+            "| 7  |",
+            "| 7  |",
+            "| 8  |",
+            "| 8  |",
             "| 8  |",
             "| 8  |",
             "+----+",
@@ -897,7 +913,7 @@ mod tests {
 
         let task_ctx = Arc::new(TaskContext::default());
         let input = ErrorExec::new();
-        let partitioning = Partitioning::RoundRobinBatch(1);
+        let partitioning = Partitioning::OnDemand(1);
         let exec =
             OnDemandRepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
 
@@ -931,7 +947,7 @@ mod tests {
 
         let schema = batch.schema();
         let input = MockExec::new(vec![Ok(batch), err], schema);
-        let partitioning = Partitioning::RoundRobinBatch(1);
+        let partitioning = Partitioning::OnDemand(1);
         let exec =
             OnDemandRepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
 
@@ -1196,12 +1212,10 @@ mod tests {
         let source2 = sorted_memory_exec(&schema, sort_exprs);
         // output has multiple partitions, and is sorted
         let union = UnionExec::new(vec![source1, source2]);
-        let exec = OnDemandRepartitionExec::try_new(
-            Arc::new(union),
-            Partitioning::OnDemand(10),
-        )
-        .unwrap()
-        .with_preserve_order();
+        let exec =
+            OnDemandRepartitionExec::try_new(Arc::new(union), Partitioning::OnDemand(10))
+                .unwrap()
+                .with_preserve_order();
 
         // Repartition should preserve order
         let expected_plan = [

--- a/datafusion/physical-plan/src/sorts/merge.rs
+++ b/datafusion/physical-plan/src/sorts/merge.rs
@@ -142,8 +142,6 @@ pub(crate) struct SortPreservingMergeStream<C: CursorValues> {
     /// vector to ensure the next iteration starts with a different partition, preventing the same partition
     /// from being continuously polled.
     uninitiated_partitions: VecDeque<usize>,
-
-    enable_pull_based_execution: bool,
 }
 
 impl<C: CursorValues> SortPreservingMergeStream<C> {
@@ -155,7 +153,6 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
         fetch: Option<usize>,
         reservation: MemoryReservation,
         enable_round_robin_tie_breaker: bool,
-        enable_pull_based_execution: bool,
     ) -> Self {
         let stream_count = streams.partitions();
 
@@ -177,7 +174,6 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
             produced: 0,
             uninitiated_partitions: (0..stream_count).collect(),
             enable_round_robin_tie_breaker,
-            enable_pull_based_execution,
         }
     }
 

--- a/datafusion/physical-plan/src/sorts/merge.rs
+++ b/datafusion/physical-plan/src/sorts/merge.rs
@@ -142,6 +142,8 @@ pub(crate) struct SortPreservingMergeStream<C: CursorValues> {
     /// vector to ensure the next iteration starts with a different partition, preventing the same partition
     /// from being continuously polled.
     uninitiated_partitions: VecDeque<usize>,
+
+    enable_pull_based_execution: bool,
 }
 
 impl<C: CursorValues> SortPreservingMergeStream<C> {
@@ -153,6 +155,7 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
         fetch: Option<usize>,
         reservation: MemoryReservation,
         enable_round_robin_tie_breaker: bool,
+        enable_pull_based_execution: bool,
     ) -> Self {
         let stream_count = streams.partitions();
 
@@ -174,6 +177,7 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
             produced: 0,
             uninitiated_partitions: (0..stream_count).collect(),
             enable_round_robin_tie_breaker,
+            enable_pull_based_execution,
         }
     }
 

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -35,7 +35,6 @@ use datafusion_execution::TaskContext;
 
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, LexRequirement};
 use log::{debug, trace};
-use tokio::stream;
 
 /// Sort preserving merge execution plan
 ///
@@ -310,7 +309,6 @@ impl ExecutionPlan for SortPreservingMergeExec {
                     .with_fetch(self.fetch)
                     .with_reservation(reservation)
                     .with_round_robin_tie_breaker(self.enable_round_robin_repartition)
-                    .with_pull_based_execution(self.enable_pull_based_execution)
                     .build()?;
 
                 debug!("Got stream result from SortPreservingMergeStream::new_from_receivers");

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -35,6 +35,7 @@ use datafusion_execution::TaskContext;
 
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, LexRequirement};
 use log::{debug, trace};
+use tokio::stream;
 
 /// Sort preserving merge execution plan
 ///
@@ -82,6 +83,7 @@ pub struct SortPreservingMergeExec {
     cache: PlanProperties,
     /// Configuration parameter to enable round-robin selection of tied winners of loser tree.
     enable_round_robin_repartition: bool,
+    enable_pull_based_execution: bool,
 }
 
 impl SortPreservingMergeExec {
@@ -95,6 +97,7 @@ impl SortPreservingMergeExec {
             fetch: None,
             cache,
             enable_round_robin_repartition: true,
+            enable_pull_based_execution: true,
         }
     }
 
@@ -190,6 +193,7 @@ impl ExecutionPlan for SortPreservingMergeExec {
             fetch: limit,
             cache: self.cache.clone(),
             enable_round_robin_repartition: true,
+            enable_pull_based_execution: true,
         }))
     }
 
@@ -271,18 +275,34 @@ impl ExecutionPlan for SortPreservingMergeExec {
                 }
             },
             _ => {
-                let receivers = (0..input_partitions)
-                    .map(|partition| {
-                        let stream =
-                            self.input.execute(partition, Arc::clone(&context))?;
-                        Ok(spawn_buffered(stream, 1))
-                    })
-                    .collect::<Result<_>>()?;
+                let streams = if self.enable_pull_based_execution {
+                    // Direct stream connection without channels
+                    let streams = (0..input_partitions)
+                        .map(|partition| {
+                            self.input.execute(partition, Arc::clone(&context))
+                        })
+                        .collect::<Result<_>>()?;
 
-                debug!("Done setting up sender-receiver for SortPreservingMergeExec::execute");
+                    debug!(
+                        "Setting up direct streams for SortPreservingMergeExec::execute"
+                    );
+                    streams
+                } else {
+                    // Channel based stream connection
+                    let receivers = (0..input_partitions)
+                        .map(|partition| {
+                            let stream =
+                                self.input.execute(partition, Arc::clone(&context))?;
+                            Ok(spawn_buffered(stream, 1))
+                        })
+                        .collect::<Result<_>>()?;
+
+                    debug!("Done setting up sender-receiver for SortPreservingMergeExec::execute");
+                    receivers
+                };
 
                 let result = StreamingMergeBuilder::new()
-                    .with_streams(receivers)
+                    .with_streams(streams)
                     .with_schema(schema)
                     .with_expressions(self.expr.as_ref())
                     .with_metrics(BaselineMetrics::new(&self.metrics, partition))
@@ -290,6 +310,7 @@ impl ExecutionPlan for SortPreservingMergeExec {
                     .with_fetch(self.fetch)
                     .with_reservation(reservation)
                     .with_round_robin_tie_breaker(self.enable_round_robin_repartition)
+                    .with_pull_based_execution(self.enable_pull_based_execution)
                     .build()?;
 
                 debug!("Got stream result from SortPreservingMergeStream::new_from_receivers");

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -345,6 +345,7 @@ mod tests {
     use crate::expressions::col;
     use crate::memory::MemoryExec;
     use crate::metrics::{MetricValue, Timestamp};
+    use crate::repartition::on_demand_repartition::OnDemandRepartitionExec;
     use crate::repartition::RepartitionExec;
     use crate::sorts::sort::SortExec;
     use crate::stream::RecordBatchReceiverStream;

--- a/datafusion/physical-plan/src/sorts/streaming_merge.rs
+++ b/datafusion/physical-plan/src/sorts/streaming_merge.rs
@@ -37,7 +37,7 @@ macro_rules! primitive_merge_helper {
 }
 
 macro_rules! merge_helper {
-    ($t:ty, $sort:ident, $streams:ident, $schema:ident, $tracking_metrics:ident, $batch_size:ident, $fetch:ident, $reservation:ident, $enable_round_robin_tie_breaker:ident) => {{
+    ($t:ty, $sort:ident, $streams:ident, $schema:ident, $tracking_metrics:ident, $batch_size:ident, $fetch:ident, $reservation:ident, $enable_round_robin_tie_breaker:ident, $enable_pull_based_execution:ident) => {{
         let streams = FieldCursorStream::<$t>::new($sort, $streams);
         return Ok(Box::pin(SortPreservingMergeStream::new(
             Box::new(streams),
@@ -47,6 +47,7 @@ macro_rules! merge_helper {
             $fetch,
             $reservation,
             $enable_round_robin_tie_breaker,
+            $enable_pull_based_execution,
         )));
     }};
 }
@@ -60,6 +61,7 @@ pub struct StreamingMergeBuilder<'a> {
     fetch: Option<usize>,
     reservation: Option<MemoryReservation>,
     enable_round_robin_tie_breaker: bool,
+    enable_pull_based_execution: bool,
 }
 
 impl Default for StreamingMergeBuilder<'_> {
@@ -73,6 +75,7 @@ impl Default for StreamingMergeBuilder<'_> {
             fetch: None,
             reservation: None,
             enable_round_robin_tie_breaker: false,
+            enable_pull_based_execution: false,
         }
     }
 }
@@ -128,6 +131,14 @@ impl<'a> StreamingMergeBuilder<'a> {
         self
     }
 
+    pub fn with_pull_based_execution(
+        mut self,
+        enable_pull_based_execution: bool,
+    ) -> Self {
+        self.enable_pull_based_execution = enable_pull_based_execution;
+        self
+    }
+
     pub fn build(self) -> Result<SendableRecordBatchStream> {
         let Self {
             streams,
@@ -138,6 +149,7 @@ impl<'a> StreamingMergeBuilder<'a> {
             fetch,
             expressions,
             enable_round_robin_tie_breaker,
+            enable_pull_based_execution,
         } = self;
 
         // Early return if streams or expressions are empty
@@ -170,11 +182,11 @@ impl<'a> StreamingMergeBuilder<'a> {
             let sort = expressions[0].clone();
             let data_type = sort.expr.data_type(schema.as_ref())?;
             downcast_primitive! {
-                data_type => (primitive_merge_helper, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker),
-                DataType::Utf8 => merge_helper!(StringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
-                DataType::LargeUtf8 => merge_helper!(LargeStringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
-                DataType::Binary => merge_helper!(BinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
-                DataType::LargeBinary => merge_helper!(LargeBinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
+                data_type => (primitive_merge_helper, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution),
+                DataType::Utf8 => merge_helper!(StringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution),
+                DataType::LargeUtf8 => merge_helper!(LargeStringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution)
+                DataType::Binary => merge_helper!(BinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution)
+                DataType::LargeBinary => merge_helper!(LargeBinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution)
                 _ => {}
             }
         }
@@ -193,6 +205,7 @@ impl<'a> StreamingMergeBuilder<'a> {
             fetch,
             reservation,
             enable_round_robin_tie_breaker,
+            enable_pull_based_execution,
         )))
     }
 }

--- a/datafusion/physical-plan/src/sorts/streaming_merge.rs
+++ b/datafusion/physical-plan/src/sorts/streaming_merge.rs
@@ -171,7 +171,7 @@ impl<'a> StreamingMergeBuilder<'a> {
             let data_type = sort.expr.data_type(schema.as_ref())?;
             downcast_primitive! {
                 data_type => (primitive_merge_helper, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker),
-                DataType::Utf8 => merge_helper!(StringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker),
+                DataType::Utf8 => merge_helper!(StringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
                 DataType::LargeUtf8 => merge_helper!(LargeStringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
                 DataType::Binary => merge_helper!(BinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
                 DataType::LargeBinary => merge_helper!(LargeBinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)

--- a/datafusion/physical-plan/src/sorts/streaming_merge.rs
+++ b/datafusion/physical-plan/src/sorts/streaming_merge.rs
@@ -37,7 +37,7 @@ macro_rules! primitive_merge_helper {
 }
 
 macro_rules! merge_helper {
-    ($t:ty, $sort:ident, $streams:ident, $schema:ident, $tracking_metrics:ident, $batch_size:ident, $fetch:ident, $reservation:ident, $enable_round_robin_tie_breaker:ident, $enable_pull_based_execution:ident) => {{
+    ($t:ty, $sort:ident, $streams:ident, $schema:ident, $tracking_metrics:ident, $batch_size:ident, $fetch:ident, $reservation:ident, $enable_round_robin_tie_breaker:ident) => {{
         let streams = FieldCursorStream::<$t>::new($sort, $streams);
         return Ok(Box::pin(SortPreservingMergeStream::new(
             Box::new(streams),
@@ -47,7 +47,6 @@ macro_rules! merge_helper {
             $fetch,
             $reservation,
             $enable_round_robin_tie_breaker,
-            $enable_pull_based_execution,
         )));
     }};
 }
@@ -61,7 +60,6 @@ pub struct StreamingMergeBuilder<'a> {
     fetch: Option<usize>,
     reservation: Option<MemoryReservation>,
     enable_round_robin_tie_breaker: bool,
-    enable_pull_based_execution: bool,
 }
 
 impl Default for StreamingMergeBuilder<'_> {
@@ -75,7 +73,6 @@ impl Default for StreamingMergeBuilder<'_> {
             fetch: None,
             reservation: None,
             enable_round_robin_tie_breaker: false,
-            enable_pull_based_execution: false,
         }
     }
 }
@@ -131,14 +128,6 @@ impl<'a> StreamingMergeBuilder<'a> {
         self
     }
 
-    pub fn with_pull_based_execution(
-        mut self,
-        enable_pull_based_execution: bool,
-    ) -> Self {
-        self.enable_pull_based_execution = enable_pull_based_execution;
-        self
-    }
-
     pub fn build(self) -> Result<SendableRecordBatchStream> {
         let Self {
             streams,
@@ -149,7 +138,6 @@ impl<'a> StreamingMergeBuilder<'a> {
             fetch,
             expressions,
             enable_round_robin_tie_breaker,
-            enable_pull_based_execution,
         } = self;
 
         // Early return if streams or expressions are empty
@@ -182,11 +170,11 @@ impl<'a> StreamingMergeBuilder<'a> {
             let sort = expressions[0].clone();
             let data_type = sort.expr.data_type(schema.as_ref())?;
             downcast_primitive! {
-                data_type => (primitive_merge_helper, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution),
-                DataType::Utf8 => merge_helper!(StringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution),
-                DataType::LargeUtf8 => merge_helper!(LargeStringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution)
-                DataType::Binary => merge_helper!(BinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution)
-                DataType::LargeBinary => merge_helper!(LargeBinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker, enable_pull_based_execution)
+                data_type => (primitive_merge_helper, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker),
+                DataType::Utf8 => merge_helper!(StringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker),
+                DataType::LargeUtf8 => merge_helper!(LargeStringArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
+                DataType::Binary => merge_helper!(BinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
+                DataType::LargeBinary => merge_helper!(LargeBinaryArray, sort, streams, schema, metrics, batch_size, fetch, reservation, enable_round_robin_tie_breaker)
                 _ => {}
             }
         }
@@ -205,7 +193,6 @@ impl<'a> StreamingMergeBuilder<'a> {
             fetch,
             reservation,
             enable_round_robin_tie_breaker,
-            enable_pull_based_execution,
         )))
     }
 }

--- a/datafusion/physical-plan/src/stream.rs
+++ b/datafusion/physical-plan/src/stream.rs
@@ -471,7 +471,11 @@ impl Stream for ObservedStream {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
+        // TODO: To be removed
+        debug!("Coalesce partitions poll ObservedStream");
         let poll = self.inner.poll_next_unpin(cx);
+        // TODO: To be removed
+        debug!("Coalesce partitions poll result {:?}", poll);
         self.baseline_metrics.record_poll(poll)
     }
 }

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -1209,6 +1209,7 @@ message Partitioning {
     uint64 round_robin = 1;
     PhysicalHashRepartition hash = 2;
     uint64 unknown = 3;
+    uint64 on_demand = 4;
   }
 }
 

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -145,6 +145,7 @@ message RepartitionNode {
   oneof partition_method {
     uint64 round_robin = 2;
     HashRepartition hash = 3;
+    uint64 on_demand = 4;
   }
 }
 

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -17853,6 +17853,11 @@ impl serde::Serialize for RepartitionNode {
                 repartition_node::PartitionMethod::Hash(v) => {
                     struct_ser.serialize_field("hash", v)?;
                 }
+                repartition_node::PartitionMethod::OnDemand(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    #[allow(clippy::needless_borrows_for_generic_args)]
+                    struct_ser.serialize_field("onDemand", ToString::to_string(&v).as_str())?;
+                }
             }
         }
         struct_ser.end()
@@ -17869,6 +17874,8 @@ impl<'de> serde::Deserialize<'de> for RepartitionNode {
             "round_robin",
             "roundRobin",
             "hash",
+            "on_demand",
+            "onDemand",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -17876,6 +17883,7 @@ impl<'de> serde::Deserialize<'de> for RepartitionNode {
             Input,
             RoundRobin,
             Hash,
+            OnDemand,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -17900,6 +17908,7 @@ impl<'de> serde::Deserialize<'de> for RepartitionNode {
                             "input" => Ok(GeneratedField::Input),
                             "roundRobin" | "round_robin" => Ok(GeneratedField::RoundRobin),
                             "hash" => Ok(GeneratedField::Hash),
+                            "onDemand" | "on_demand" => Ok(GeneratedField::OnDemand),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -17941,6 +17950,12 @@ impl<'de> serde::Deserialize<'de> for RepartitionNode {
                             }
                             partition_method__ = map_.next_value::<::std::option::Option<_>>()?.map(repartition_node::PartitionMethod::Hash)
 ;
+                        }
+                        GeneratedField::OnDemand => {
+                            if partition_method__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("onDemand"));
+                            }
+                            partition_method__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| repartition_node::PartitionMethod::OnDemand(x.0));
                         }
                     }
                 }

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -12936,6 +12936,11 @@ impl serde::Serialize for Partitioning {
                     #[allow(clippy::needless_borrows_for_generic_args)]
                     struct_ser.serialize_field("unknown", ToString::to_string(&v).as_str())?;
                 }
+                partitioning::PartitionMethod::OnDemand(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    #[allow(clippy::needless_borrows_for_generic_args)]
+                    struct_ser.serialize_field("onDemand", ToString::to_string(&v).as_str())?;
+                }
             }
         }
         struct_ser.end()
@@ -12952,6 +12957,8 @@ impl<'de> serde::Deserialize<'de> for Partitioning {
             "roundRobin",
             "hash",
             "unknown",
+            "on_demand",
+            "onDemand",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -12959,6 +12966,7 @@ impl<'de> serde::Deserialize<'de> for Partitioning {
             RoundRobin,
             Hash,
             Unknown,
+            OnDemand,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -12983,6 +12991,7 @@ impl<'de> serde::Deserialize<'de> for Partitioning {
                             "roundRobin" | "round_robin" => Ok(GeneratedField::RoundRobin),
                             "hash" => Ok(GeneratedField::Hash),
                             "unknown" => Ok(GeneratedField::Unknown),
+                            "onDemand" | "on_demand" => Ok(GeneratedField::OnDemand),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -13023,6 +13032,12 @@ impl<'de> serde::Deserialize<'de> for Partitioning {
                                 return Err(serde::de::Error::duplicate_field("unknown"));
                             }
                             partition_method__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| partitioning::PartitionMethod::Unknown(x.0));
+                        }
+                        GeneratedField::OnDemand => {
+                            if partition_method__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("onDemand"));
+                            }
+                            partition_method__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| partitioning::PartitionMethod::OnDemand(x.0));
                         }
                     }
                 }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1756,7 +1756,7 @@ pub struct RepartitionExecNode {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Partitioning {
-    #[prost(oneof = "partitioning::PartitionMethod", tags = "1, 2, 3")]
+    #[prost(oneof = "partitioning::PartitionMethod", tags = "1, 2, 3, 4")]
     pub partition_method: ::core::option::Option<partitioning::PartitionMethod>,
 }
 /// Nested message and enum types in `Partitioning`.
@@ -1769,6 +1769,8 @@ pub mod partitioning {
         Hash(super::PhysicalHashRepartition),
         #[prost(uint64, tag = "3")]
         Unknown(u64),
+        #[prost(uint64, tag = "4")]
+        OnDemand(u64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -205,7 +205,7 @@ pub struct SortNode {
 pub struct RepartitionNode {
     #[prost(message, optional, boxed, tag = "1")]
     pub input: ::core::option::Option<::prost::alloc::boxed::Box<LogicalPlanNode>>,
-    #[prost(oneof = "repartition_node::PartitionMethod", tags = "2, 3")]
+    #[prost(oneof = "repartition_node::PartitionMethod", tags = "2, 3, 4")]
     pub partition_method: ::core::option::Option<repartition_node::PartitionMethod>,
 }
 /// Nested message and enum types in `RepartitionNode`.
@@ -216,6 +216,8 @@ pub mod repartition_node {
         RoundRobin(u64),
         #[prost(message, tag = "3")]
         Hash(super::HashRepartition),
+        #[prost(uint64, tag = "4")]
+        OnDemand(u64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -447,6 +447,9 @@ pub fn parse_protobuf_partitioning(
             )) => Ok(Some(Partitioning::RoundRobinBatch(
                 *partition_count as usize,
             ))),
+            Some(protobuf::partitioning::PartitionMethod::OnDemand(partition_count)) => {
+                Ok(Some(Partitioning::OnDemand(*partition_count as usize)))
+            }
             Some(protobuf::partitioning::PartitionMethod::Hash(hash_repartition)) => {
                 parse_protobuf_hash_partitioning(
                     Some(hash_repartition),

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -396,6 +396,11 @@ pub fn serialize_partitioning(
                 *partition_count as u64,
             )),
         },
+        Partitioning::OnDemand(partition_count) => protobuf::Partitioning {
+            partition_method: Some(protobuf::partitioning::PartitionMethod::OnDemand(
+                *partition_count as u64,
+            )),
+        },
         Partitioning::Hash(exprs, partition_count) => {
             let serialized_exprs = serialize_physical_exprs(exprs, codec)?;
             protobuf::Partitioning {

--- a/datafusion/sqllogictest/test_files/agg_func_substitute.slt
+++ b/datafusion/sqllogictest/test_files/agg_func_substitute.slt
@@ -49,7 +49,7 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4
 06)----------AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[nth_value(multiple_ordered_table.c,Int64(1)) ORDER BY [multiple_ordered_table.c ASC NULLS LAST]], ordering_mode=Sorted
-07)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 08)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, c], output_orderings=[[a@0 ASC NULLS LAST], [c@1 ASC NULLS LAST]], has_header=true
 
 
@@ -69,7 +69,7 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4
 06)----------AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[nth_value(multiple_ordered_table.c,Int64(1)) ORDER BY [multiple_ordered_table.c ASC NULLS LAST]], ordering_mode=Sorted
-07)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 08)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, c], output_orderings=[[a@0 ASC NULLS LAST], [c@1 ASC NULLS LAST]], has_header=true
 
 query TT
@@ -88,7 +88,7 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4
 06)----------AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[nth_value(multiple_ordered_table.c,Int64(1) + Int64(100)) ORDER BY [multiple_ordered_table.c ASC NULLS LAST]], ordering_mode=Sorted
-07)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 08)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, c], output_orderings=[[a@0 ASC NULLS LAST], [c@1 ASC NULLS LAST]], has_header=true
 
 query II

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -147,7 +147,7 @@ physical_plan
 02)--CoalescePartitionsExec
 03)----AggregateExec: mode=Partial, gby=[], aggr=[array_agg(agg_order.c1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]
 04)------SortExec: expr=[c2@1 DESC, c3@2 ASC NULLS LAST], preserve_partitioning=[true]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/aggregate_agg_multi_order.csv]]}, projection=[c1, c2, c3], has_header=true
 
 # test array_agg_order with list data type
@@ -1000,7 +1000,7 @@ physical_plan
 05)--------AggregateExec: mode=FinalPartitioned, gby=[alias1@0 as alias1], aggr=[]
 06)----------CoalesceBatchesExec: target_batch_size=8192
 07)------------RepartitionExec: partitioning=Hash([alias1@0], 4), input_partitions=4
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)----------------AggregateExec: mode=Partial, gby=[c@0 as alias1], aggr=[]
 10)------------------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -4935,7 +4935,7 @@ physical_plan
 08)--------------CoalesceBatchesExec: target_batch_size=8192
 09)----------------RepartitionExec: partitioning=Hash([c3@0], 4), input_partitions=4
 10)------------------AggregateExec: mode=Partial, gby=[c3@1 as c3], aggr=[min(aggregate_test_100.c1)]
-11)--------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+11)--------------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 12)----------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c3], has_header=true
 
 
@@ -4960,7 +4960,7 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[c3@0 as c3], aggr=[], lim=[5]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[c3@0 as c3], aggr=[], lim=[5]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c3], has_header=true
 
 query I
@@ -4984,7 +4984,7 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[c2@0 as c2, c3@1 as c3], aggr=[], lim=[9]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[c2@0 as c2, c3@1 as c3], aggr=[], lim=[9]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c2, c3], has_header=true
 
 query II
@@ -5012,14 +5012,14 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[c3@0 as c3], aggr=[], lim=[4]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[c3@0 as c3], aggr=[], lim=[4]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------ProjectionExec: expr=[c3@1 as c3]
 07)------------AggregateExec: mode=Final, gby=[c2@0 as c2, c3@1 as c3], aggr=[]
 08)--------------CoalescePartitionsExec
 09)----------------AggregateExec: mode=Partial, gby=[c2@0 as c2, c3@1 as c3], aggr=[]
 10)------------------CoalesceBatchesExec: target_batch_size=8192
 11)--------------------FilterExec: c3@1 >= 10 AND c3@1 <= 20
-12)----------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+12)----------------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 13)------------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c2, c3], has_header=true
 
 query I
@@ -5045,7 +5045,7 @@ physical_plan
 03)----AggregateExec: mode=Final, gby=[c2@0 as c2, c3@1 as c3], aggr=[max(aggregate_test_100.c1)]
 04)------CoalescePartitionsExec
 05)--------AggregateExec: mode=Partial, gby=[c2@1 as c2, c3@2 as c3], aggr=[max(aggregate_test_100.c1)]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2, c3], has_header=true
 
 # TODO(msirek): Extend checking in LimitedDistinctAggregation equal groupings to ignore the order of columns
@@ -5064,12 +5064,12 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[c3@0 as c3, c2@1 as c2], aggr=[], lim=[13]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[c3@0 as c3, c2@1 as c2], aggr=[], lim=[13]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------ProjectionExec: expr=[c3@1 as c3, c2@0 as c2]
 07)------------AggregateExec: mode=Final, gby=[c2@0 as c2, c3@1 as c3], aggr=[]
 08)--------------CoalescePartitionsExec
 09)----------------AggregateExec: mode=Partial, gby=[c2@0 as c2, c3@1 as c3], aggr=[]
-10)------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+10)------------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 11)--------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c2, c3], has_header=true
 
 query II
@@ -5093,7 +5093,7 @@ physical_plan
 03)----AggregateExec: mode=Final, gby=[c2@0 as c2, c3@1 as c3, __grouping_id@2 as __grouping_id], aggr=[], lim=[3]
 04)------CoalescePartitionsExec
 05)--------AggregateExec: mode=Partial, gby=[(NULL as c2, NULL as c3), (c2@0 as c2, NULL as c3), (c2@0 as c2, c3@1 as c3)], aggr=[]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c2, c3], has_header=true
 
 query II
@@ -5120,7 +5120,7 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[c3@0 as c3], aggr=[]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[c3@0 as c3], aggr=[]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c3], has_header=true
 
 statement ok
@@ -5905,7 +5905,7 @@ physical_plan
 01)AggregateExec: mode=Final, gby=[], aggr=[first_value(convert_first_last_table.c1) ORDER BY [convert_first_last_table.c3 DESC NULLS FIRST]]
 02)--CoalescePartitionsExec
 03)----AggregateExec: mode=Partial, gby=[], aggr=[last_value(convert_first_last_table.c1) ORDER BY [convert_first_last_table.c3 ASC NULLS LAST]]
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/convert_first_last.csv]]}, projection=[c1, c3], output_orderings=[[c1@0 ASC NULLS LAST], [c3@1 ASC NULLS LAST]], has_header=true
 
 # test last to first
@@ -5919,7 +5919,7 @@ physical_plan
 01)AggregateExec: mode=Final, gby=[], aggr=[last_value(convert_first_last_table.c1) ORDER BY [convert_first_last_table.c2 ASC NULLS LAST]]
 02)--CoalescePartitionsExec
 03)----AggregateExec: mode=Partial, gby=[], aggr=[first_value(convert_first_last_table.c1) ORDER BY [convert_first_last_table.c2 DESC NULLS FIRST]]
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/convert_first_last.csv]]}, projection=[c1, c2], output_orderings=[[c1@0 ASC NULLS LAST], [c2@1 DESC]], has_header=true
 
 # test building plan with aggreagte sum
@@ -5991,7 +5991,7 @@ physical_plan
 03)----AggregateExec: mode=FinalPartitioned, gby=[v1@0 as v1, v2@1 as v2], aggr=[max(having_test.v1)]
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([v1@0, v2@1], 4), input_partitions=4
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------AggregateExec: mode=Partial, gby=[v1@0 as v1, v2@1 as v2], aggr=[max(having_test.v1)]
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -49,7 +49,7 @@ physical_plan
 03)----AggregateExec: mode=FinalPartitioned, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)]
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([trace_id@0], 4), input_partitions=4
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------AggregateExec: mode=Partial, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)]
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -113,7 +113,7 @@ physical_plan
 03)----AggregateExec: mode=FinalPartitioned, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)], lim=[4]
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([trace_id@0], 4), input_partitions=4
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------AggregateExec: mode=Partial, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)], lim=[4]
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -130,7 +130,7 @@ physical_plan
 03)----AggregateExec: mode=FinalPartitioned, gby=[trace_id@0 as trace_id], aggr=[min(traces.timestamp)]
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([trace_id@0], 4), input_partitions=4
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------AggregateExec: mode=Partial, gby=[trace_id@0 as trace_id], aggr=[min(traces.timestamp)]
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -147,7 +147,7 @@ physical_plan
 03)----AggregateExec: mode=FinalPartitioned, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)]
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([trace_id@0], 4), input_partitions=4
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------AggregateExec: mode=Partial, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)]
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -164,7 +164,7 @@ physical_plan
 03)----AggregateExec: mode=FinalPartitioned, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)]
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------RepartitionExec: partitioning=Hash([trace_id@0], 4), input_partitions=4
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------AggregateExec: mode=Partial, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)]
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 

--- a/datafusion/sqllogictest/test_files/count_star_rule.slt
+++ b/datafusion/sqllogictest/test_files/count_star_rule.slt
@@ -48,7 +48,7 @@ physical_plan
 01)AggregateExec: mode=FinalPartitioned, gby=[a@0 as a], aggr=[count()]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[count()]
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -67,7 +67,7 @@ physical_plan
 04)------AggregateExec: mode=FinalPartitioned, gby=[a@0 as a], aggr=[count()]
 05)--------CoalesceBatchesExec: target_batch_size=8192
 06)----------RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4
-07)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 08)--------------AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[count()]
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -119,7 +119,7 @@ physical_plan
 05)----ProjectionExec: expr=[id@0 + 1 as id]
 06)------CoalesceBatchesExec: target_batch_size=8192
 07)--------FilterExec: id@0 < 10
-08)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)------------WorkTableExec: name=nodes
 
 # setup
@@ -165,7 +165,7 @@ physical_plan
 05)------ProjectionExec: expr=[time@0 + 1 as time, name@1 as name, account_balance@2 + 10 as account_balance]
 06)--------CoalesceBatchesExec: target_batch_size=2
 07)----------FilterExec: time@0 < 10
-08)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)--------------WorkTableExec: name=balances
 
 # recursive CTE with static term derived from table works
@@ -722,7 +722,7 @@ logical_plan
 03)----Projection: Int64(1) AS val
 04)------EmptyRelation
 05)----Projection: Int64(2) AS val
-06)------Cross Join:
+06)------Cross Join: 
 07)--------Filter: recursive_cte.val < Int64(2)
 08)----------TableScan: recursive_cte
 09)--------SubqueryAlias: sub_cte
@@ -737,7 +737,7 @@ physical_plan
 06)------CoalescePartitionsExec
 07)--------CoalesceBatchesExec: target_batch_size=8182
 08)----------FilterExec: val@0 < 2
-09)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+09)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 10)--------------WorkTableExec: name=recursive_cte
 11)------ProjectionExec: expr=[2 as val]
 12)--------PlaceholderRowExec

--- a/datafusion/sqllogictest/test_files/distinct_on.slt
+++ b/datafusion/sqllogictest/test_files/distinct_on.slt
@@ -101,7 +101,7 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=8192
 06)----------RepartitionExec: partitioning=Hash([c1@0], 4), input_partitions=4
 07)------------AggregateExec: mode=Partial, gby=[c1@0 as c1], aggr=[first_value(aggregate_test_100.c3) ORDER BY [aggregate_test_100.c1 ASC NULLS LAST, aggregate_test_100.c3 ASC NULLS LAST], first_value(aggregate_test_100.c2) ORDER BY [aggregate_test_100.c1 ASC NULLS LAST, aggregate_test_100.c3 ASC NULLS LAST]]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)----------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2, c3], has_header=true
 
 # ON expressions are not a sub-set of the ORDER BY expressions

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -45,7 +45,7 @@ logical_plan
 physical_plan
 01)CoalesceBatchesExec: target_batch_size=8192
 02)--FilterExec: c2@1 > 10, projection=[c1@0]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2], has_header=true
 
 # explain_csv_exec_scan_config

--- a/datafusion/sqllogictest/test_files/filter_without_sort_exec.slt
+++ b/datafusion/sqllogictest/test_files/filter_without_sort_exec.slt
@@ -40,7 +40,7 @@ physical_plan
 01)SortPreservingMergeExec: [date@0 ASC NULLS LAST, time@2 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: ticker@1 = A
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------StreamingTableExec: partition_sizes=1, projection=[date, ticker, time], infinite_source=true, output_ordering=[date@0 ASC NULLS LAST, ticker@1 ASC NULLS LAST, time@2 ASC NULLS LAST]
 
 # constant ticker, CAST(time AS DATE) = time, order by time
@@ -57,7 +57,7 @@ physical_plan
 01)SortPreservingMergeExec: [time@2 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: ticker@1 = A AND CAST(time@2 AS Date32) = date@0
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------StreamingTableExec: partition_sizes=1, projection=[date, ticker, time], infinite_source=true, output_ordering=[date@0 ASC NULLS LAST, ticker@1 ASC NULLS LAST, time@2 ASC NULLS LAST]
 
 # same thing but order by date
@@ -74,7 +74,7 @@ physical_plan
 01)SortPreservingMergeExec: [date@0 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: ticker@1 = A AND CAST(time@2 AS Date32) = date@0
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------StreamingTableExec: partition_sizes=1, projection=[date, ticker, time], infinite_source=true, output_ordering=[date@0 ASC NULLS LAST, ticker@1 ASC NULLS LAST, time@2 ASC NULLS LAST]
 
 # same thing but order by ticker
@@ -91,7 +91,7 @@ physical_plan
 01)CoalescePartitionsExec
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: ticker@1 = A AND CAST(time@2 AS Date32) = date@0
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------StreamingTableExec: partition_sizes=1, projection=[date, ticker, time], infinite_source=true, output_ordering=[date@0 ASC NULLS LAST, ticker@1 ASC NULLS LAST, time@2 ASC NULLS LAST]
 
 # same thing but order by time, date
@@ -108,7 +108,7 @@ physical_plan
 01)SortPreservingMergeExec: [time@2 ASC NULLS LAST, date@0 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: ticker@1 = A AND CAST(time@2 AS Date32) = date@0
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------StreamingTableExec: partition_sizes=1, projection=[date, ticker, time], infinite_source=true, output_ordering=[date@0 ASC NULLS LAST, ticker@1 ASC NULLS LAST, time@2 ASC NULLS LAST]
 
 # CAST(time AS DATE) <> date (should require a sort)
@@ -149,5 +149,5 @@ physical_plan
 01)SortPreservingMergeExec: [ticker@1 ASC NULLS LAST, time@2 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: date@0 = 2006-01-02
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------StreamingTableExec: partition_sizes=1, projection=[date, ticker, time], infinite_source=true, output_ordering=[date@0 ASC NULLS LAST, ticker@1 ASC NULLS LAST, time@2 ASC NULLS LAST]

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -2020,7 +2020,7 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=8192
 06)----------RepartitionExec: partitioning=Hash([col0@0, col1@1, col2@2], 4), input_partitions=4
 07)------------AggregateExec: mode=Partial, gby=[col0@0 as col0, col1@1 as col1, col2@2 as col2], aggr=[last_value(r.col1) ORDER BY [r.col0 ASC NULLS LAST]]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)----------------ProjectionExec: expr=[col0@2 as col0, col1@3 as col1, col2@4 as col2, col0@0 as col0, col1@1 as col1]
 10)------------------CoalesceBatchesExec: target_batch_size=8192
 11)--------------------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(col0@0, col0@0)]
@@ -2922,7 +2922,7 @@ physical_plan
 04)------AggregateExec: mode=FinalPartitioned, gby=[country@0 as country], aggr=[first_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST], last_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST]]
 05)--------CoalesceBatchesExec: target_batch_size=8192
 06)----------RepartitionExec: partitioning=Hash([country@0], 8), input_partitions=8
-07)------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 08)--------------AggregateExec: mode=Partial, gby=[country@0 as country], aggr=[first_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST], last_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST]]
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -2958,7 +2958,7 @@ physical_plan
 04)------AggregateExec: mode=FinalPartitioned, gby=[country@0 as country], aggr=[first_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST], last_value(sales_global.amount) ORDER BY [sales_global.ts DESC NULLS FIRST]]
 05)--------CoalesceBatchesExec: target_batch_size=8192
 06)----------RepartitionExec: partitioning=Hash([country@0], 8), input_partitions=8
-07)------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 08)--------------AggregateExec: mode=Partial, gby=[country@0 as country], aggr=[first_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST], last_value(sales_global.amount) ORDER BY [sales_global.ts DESC NULLS FIRST]]
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -2995,7 +2995,7 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[], aggr=[first_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST], last_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST]]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[], aggr=[first_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST], last_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST]]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 query RR
@@ -3021,7 +3021,7 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[], aggr=[first_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST], last_value(sales_global.amount) ORDER BY [sales_global.ts DESC NULLS FIRST]]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[], aggr=[first_value(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST], last_value(sales_global.amount) ORDER BY [sales_global.ts DESC NULLS FIRST]]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 query RR
@@ -3046,7 +3046,7 @@ physical_plan
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[], aggr=[array_agg(sales_global.amount) ORDER BY [sales_global.ts ASC NULLS LAST]]
 05)--------SortExec: expr=[ts@0 ASC NULLS LAST], preserve_partitioning=[true]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query ?
@@ -3070,7 +3070,7 @@ physical_plan
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[], aggr=[array_agg(sales_global.amount) ORDER BY [sales_global.ts DESC NULLS FIRST]]
 05)--------SortExec: expr=[ts@0 DESC], preserve_partitioning=[true]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query ?
@@ -3094,7 +3094,7 @@ physical_plan
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[], aggr=[array_agg(sales_global.amount) ORDER BY [sales_global.amount ASC NULLS LAST]]
 05)--------SortExec: expr=[amount@0 ASC NULLS LAST], preserve_partitioning=[true]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query ?
@@ -3124,7 +3124,7 @@ physical_plan
 06)----------RepartitionExec: partitioning=Hash([country@0], 8), input_partitions=8
 07)------------AggregateExec: mode=Partial, gby=[country@0 as country], aggr=[array_agg(sales_global.amount) ORDER BY [sales_global.amount ASC NULLS LAST]]
 08)--------------SortExec: expr=[amount@1 ASC NULLS LAST], preserve_partitioning=[true]
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 10)------------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query T?
@@ -3160,7 +3160,7 @@ physical_plan
 06)----------RepartitionExec: partitioning=Hash([country@0], 8), input_partitions=8
 07)------------AggregateExec: mode=Partial, gby=[country@0 as country], aggr=[array_agg(sales_global.amount) ORDER BY [sales_global.amount DESC NULLS FIRST], last_value(sales_global.amount) ORDER BY [sales_global.amount DESC NULLS FIRST], last_value(sales_global.amount) ORDER BY [sales_global.amount DESC NULLS FIRST]]
 08)--------------SortExec: expr=[amount@1 DESC], preserve_partitioning=[true]
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 10)------------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query T?RR
@@ -3360,7 +3360,7 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=4
 06)----------RepartitionExec: partitioning=Hash([sn@0, amount@1], 8), input_partitions=8
 07)------------AggregateExec: mode=Partial, gby=[sn@0 as sn, amount@1 as amount], aggr=[]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query IRI
@@ -3432,7 +3432,7 @@ physical_plan
 08)--------------ProjectionExec: expr=[amount@1 as amount, sn@2 as sn, amount@3 as amount]
 09)----------------NestedLoopJoinExec: join_type=Inner, filter=sn@0 >= sn@1
 10)------------------MemoryExec: partitions=1, partition_sizes=[1]
-11)------------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+11)------------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 12)--------------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query IRR
@@ -3577,7 +3577,7 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=4
 06)----------RepartitionExec: partitioning=Hash([sn@0, zip_code@1, country@2, ts@3, currency@4, amount@5, sum_amount@6], 8), input_partitions=8
 07)------------AggregateExec: mode=Partial, gby=[sn@2 as sn, zip_code@0 as zip_code, country@1 as country, ts@3 as ts, currency@4 as currency, amount@5 as amount, sum_amount@6 as sum_amount], aggr=[]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 09)----------------ProjectionExec: expr=[zip_code@0 as zip_code, country@1 as country, sn@2 as sn, ts@3 as ts, currency@4 as currency, amount@5 as amount, sum(l.amount) ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING@6 as sum_amount]
 10)------------------BoundedWindowAggExec: wdw=[sum(l.amount) ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING: Ok(Field { name: "sum(l.amount) ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(1)), end_bound: Following(UInt64(1)), is_causal: false }], mode=[Sorted]
 11)--------------------MemoryExec: partitions=1, partition_sizes=[1]
@@ -3762,7 +3762,7 @@ physical_plan
 01)AggregateExec: mode=Final, gby=[], aggr=[last_value(foo.x)]
 02)--CoalescePartitionsExec
 03)----AggregateExec: mode=Partial, gby=[], aggr=[last_value(foo.x)]
-04)------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 05)--------MemoryExec: partitions=1, partition_sizes=[1]
 
 query I
@@ -3784,7 +3784,7 @@ physical_plan
 01)AggregateExec: mode=Final, gby=[], aggr=[first_value(foo.x)]
 02)--CoalescePartitionsExec
 03)----AggregateExec: mode=Partial, gby=[], aggr=[first_value(foo.x)]
-04)------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 05)--------MemoryExec: partitions=1, partition_sizes=[1]
 
 # Since both ordering requirements are satisfied, there shouldn't be
@@ -3805,7 +3805,7 @@ physical_plan
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([d@0], 8), input_partitions=8
 05)--------AggregateExec: mode=Partial, gby=[d@2 as d], aggr=[first_value(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.a ASC NULLS LAST], first_value(multiple_ordered_table.c) ORDER BY [multiple_ordered_table.c ASC NULLS LAST]]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 07)------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, c, d], output_orderings=[[a@0 ASC NULLS LAST], [c@1 ASC NULLS LAST]], has_header=true
 
 query II rowsort
@@ -3917,7 +3917,7 @@ physical_plan
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([c@0, b@1], 8), input_partitions=8
 05)--------AggregateExec: mode=Partial, gby=[c@1 as c, b@0 as b], aggr=[sum(multiple_ordered_table_with_pk.d)], ordering_mode=PartiallySorted([0])
-06)----------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 07)------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[b, c, d], output_ordering=[c@1 ASC NULLS LAST], has_header=true
 
 # drop table multiple_ordered_table_with_pk
@@ -3958,7 +3958,7 @@ physical_plan
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([c@0, b@1], 8), input_partitions=8
 05)--------AggregateExec: mode=Partial, gby=[c@1 as c, b@0 as b], aggr=[sum(multiple_ordered_table_with_pk.d)], ordering_mode=PartiallySorted([0])
-06)----------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 07)------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[b, c, d], output_ordering=[c@1 ASC NULLS LAST], has_header=true
 
 statement ok
@@ -4179,7 +4179,7 @@ physical_plan
 02)--AggregateExec: mode=FinalPartitioned, gby=[y@0 as y], aggr=[sum(DISTINCT t1.x), max(DISTINCT t1.x)]
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([y@0], 8), input_partitions=8
-05)--------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 06)----------AggregateExec: mode=Partial, gby=[y@1 as y], aggr=[sum(DISTINCT t1.x), max(DISTINCT t1.x)]
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 
@@ -4201,7 +4201,7 @@ physical_plan
 06)----------AggregateExec: mode=FinalPartitioned, gby=[y@0 as y, alias1@1 as alias1], aggr=[]
 07)------------CoalesceBatchesExec: target_batch_size=2
 08)--------------RepartitionExec: partitioning=Hash([y@0, alias1@1], 8), input_partitions=8
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 10)------------------AggregateExec: mode=Partial, gby=[y@1 as y, __common_expr_1@0 as alias1], aggr=[]
 11)--------------------ProjectionExec: expr=[CAST(x@0 AS Float64) as __common_expr_1, y@1 as y]
 12)----------------------MemoryExec: partitions=1, partition_sizes=[1]
@@ -4236,7 +4236,7 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([date_bin(Utf8("15 minutes"),unbounded_csv_with_timestamps.ts)@0], 8), input_partitions=8, preserve_order=true, sort_exprs=date_bin(Utf8("15 minutes"),unbounded_csv_with_timestamps.ts)@0 DESC
 06)----------AggregateExec: mode=Partial, gby=[date_bin(IntervalMonthDayNano { months: 0, days: 0, nanoseconds: 900000000000 }, ts@0) as date_bin(Utf8("15 minutes"),unbounded_csv_with_timestamps.ts)], aggr=[], ordering_mode=Sorted
-07)------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 08)--------------StreamingTableExec: partition_sizes=1, projection=[ts], infinite_source=true, output_ordering=[ts@0 DESC]
 
 query P
@@ -4291,7 +4291,7 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=2
 06)----------RepartitionExec: partitioning=Hash([date_part(Utf8("MONTH"),csv_with_timestamps.ts)@0], 8), input_partitions=8
 07)------------AggregateExec: mode=Partial, gby=[date_part(MONTH, ts@0) as date_part(Utf8("MONTH"),csv_with_timestamps.ts)], aggr=[]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 09)----------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/timestamps.csv]]}, projection=[ts], output_ordering=[ts@0 DESC], has_header=false
 
 query I
@@ -4331,7 +4331,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [name@0 DESC, time_chunks@1 DESC], fetch=5
 02)--ProjectionExec: expr=[name@0 as name, date_bin(IntervalMonthDayNano { months: 0, days: 0, nanoseconds: 900000000000 }, ts@1) as time_chunks]
-03)----RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 04)------StreamingTableExec: partition_sizes=1, projection=[name, ts], infinite_source=true, output_ordering=[name@0 DESC, ts@1 DESC]
 
 statement ok
@@ -4407,7 +4407,7 @@ physical_plan
 09)----------------CoalesceBatchesExec: target_batch_size=2
 10)------------------RepartitionExec: partitioning=Hash([c1@0, alias1@1], 8), input_partitions=8
 11)--------------------AggregateExec: mode=Partial, gby=[c1@0 as c1, c2@1 as alias1], aggr=[alias2, alias3]
-12)----------------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+12)----------------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 13)------------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2, c3, c4], has_header=true
 
 # Use PostgreSQL dialect
@@ -4580,7 +4580,7 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([c2@0], 8), input_partitions=8
 06)----------AggregateExec: mode=Partial, gby=[c2@1 as c2], aggr=[max(timestamp_table.t1)], lim=[4]
-07)------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=4
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=4
 08)--------------CsvExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/group_by/timestamp_table/0.csv], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/group_by/timestamp_table/1.csv], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/group_by/timestamp_table/2.csv], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/group_by/timestamp_table/3.csv]]}, projection=[t1, c2], has_header=true
 
 # Clean up

--- a/datafusion/sqllogictest/test_files/information_schema.slt
+++ b/datafusion/sqllogictest/test_files/information_schema.slt
@@ -238,6 +238,7 @@ datafusion.explain.show_statistics false
 datafusion.optimizer.allow_symmetric_joins_without_pruning true
 datafusion.optimizer.default_filter_selectivity 20
 datafusion.optimizer.enable_distinct_aggregation_soft_limit true
+datafusion.optimizer.enable_on_demand_repartition true
 datafusion.optimizer.enable_round_robin_repartition true
 datafusion.optimizer.enable_topk_aggregation true
 datafusion.optimizer.expand_views_at_output false
@@ -331,6 +332,7 @@ datafusion.explain.show_statistics false When set to true, the explain statement
 datafusion.optimizer.allow_symmetric_joins_without_pruning true Should DataFusion allow symmetric hash joins for unbounded data sources even when its inputs do not have any ordering or filtering If the flag is not enabled, the SymmetricHashJoin operator will be unable to prune its internal buffers, resulting in certain join types - such as Full, Left, LeftAnti, LeftSemi, Right, RightAnti, and RightSemi - being produced only at the end of the execution. This is not typical in stream processing. Additionally, without proper design for long runner execution, all types of joins may encounter out-of-memory errors.
 datafusion.optimizer.default_filter_selectivity 20 The default filter selectivity used by Filter Statistics when an exact selectivity cannot be determined. Valid values are between 0 (no selectivity) and 100 (all rows are selected).
 datafusion.optimizer.enable_distinct_aggregation_soft_limit true When set to true, the optimizer will push a limit operation into grouped aggregations which have no aggregate expressions, as a soft limit, emitting groups once the limit is reached, before all rows in the group are read.
+datafusion.optimizer.enable_on_demand_repartition true (empty)
 datafusion.optimizer.enable_round_robin_repartition true When set to true, the physical plan optimizer will try to add round robin repartitioning to increase parallelism to leverage more CPU cores
 datafusion.optimizer.enable_topk_aggregation true When set to true, the optimizer will attempt to perform limit operations during aggregations, if possible
 datafusion.optimizer.expand_views_at_output false When set to true, if the returned type is a view type then the output will be coerced to a non-view. Coerces `Utf8View` to `LargeUtf8`, and `BinaryView` to `LargeBinary`.

--- a/datafusion/sqllogictest/test_files/insert.slt
+++ b/datafusion/sqllogictest/test_files/insert.slt
@@ -72,7 +72,7 @@ physical_plan
 06)----------SortExec: expr=[c1@0 ASC NULLS LAST, c9@2 ASC NULLS LAST], preserve_partitioning=[true]
 07)------------CoalesceBatchesExec: target_batch_size=8192
 08)--------------RepartitionExec: partitioning=Hash([c1@0], 8), input_partitions=8
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 10)------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c4, c9], has_header=true
 
 query I
@@ -132,7 +132,7 @@ physical_plan
 05)--------SortExec: expr=[c1@0 ASC NULLS LAST, c9@2 ASC NULLS LAST], preserve_partitioning=[true]
 06)----------CoalesceBatchesExec: target_batch_size=8192
 07)------------RepartitionExec: partitioning=Hash([c1@0], 8), input_partitions=8
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 09)----------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c4, c9], has_header=true
 
 
@@ -183,7 +183,7 @@ physical_plan
 06)----------SortExec: expr=[c1@0 ASC NULLS LAST, c9@2 ASC NULLS LAST], preserve_partitioning=[true]
 07)------------CoalesceBatchesExec: target_batch_size=8192
 08)--------------RepartitionExec: partitioning=Hash([c1@0], 8), input_partitions=8
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 10)------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c4, c9], has_header=true
 
 

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -361,7 +361,7 @@ physical_plan
 06)----------SortExec: expr=[c1@0 ASC NULLS LAST, c9@2 ASC NULLS LAST], preserve_partitioning=[true]
 07)------------CoalesceBatchesExec: target_batch_size=8192
 08)--------------RepartitionExec: partitioning=Hash([c1@0], 8), input_partitions=8
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 10)------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c4, c9], has_header=true
 
 query I
@@ -422,7 +422,7 @@ physical_plan
 05)--------SortExec: expr=[c1@0 ASC NULLS LAST, c9@2 ASC NULLS LAST], preserve_partitioning=[true]
 06)----------CoalesceBatchesExec: target_batch_size=8192
 07)------------RepartitionExec: partitioning=Hash([c1@0], 8), input_partitions=8
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(8), input_partitions=1
 09)----------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c4, c9], has_header=true
 
 

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -671,13 +671,13 @@ query TT
 explain select * from t1 inner join t2 on true;
 ----
 logical_plan
-01)Cross Join:
+01)Cross Join: 
 02)--TableScan: t1 projection=[t1_id, t1_name, t1_int]
 03)--TableScan: t2 projection=[t2_id, t2_name, t2_int]
 physical_plan
 01)CrossJoinExec
 02)--MemoryExec: partitions=1, partition_sizes=[1]
-03)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)--OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)----MemoryExec: partitions=1, partition_sizes=[1]
 
 statement ok
@@ -963,7 +963,7 @@ logical_plan
 physical_plan
 01)CoalesceBatchesExec: target_batch_size=8192
 02)--FilterExec: dept_name@2 != Engineering AND name@1 = Alice OR name@1 != Alice AND name@1 = Carol
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CoalesceBatchesExec: target_batch_size=8192
 05)--------HashJoinExec: mode=CollectLeft, join_type=Left, on=[(emp_id@0, emp_id@0)], projection=[emp_id@0, name@1, dept_name@3]
 06)----------CoalesceBatchesExec: target_batch_size=8192
@@ -1161,7 +1161,7 @@ physical_plan
 02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(t1.v0 AS Float64)@6, v1@1)], filter=v1@1 + CAST(v0@0 AS Float64) > 0, projection=[v0@0, v1@1, v2@3, v3@4, v4@5, v0@7, v1@8]
 03)----CoalescePartitionsExec
 04)------ProjectionExec: expr=[v0@0 as v0, v1@1 as v1, v0@2 as v0, v2@3 as v2, v3@4 as v3, v4@5 as v4, CAST(v0@0 AS Float64) as CAST(t1.v0 AS Float64)]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------CoalesceBatchesExec: target_batch_size=8192
 07)------------HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(v0@0, v0@0), (v1@1, v1@1)], projection=[v0@0, v1@1, v0@2, v2@4, v3@5, v4@6]
 08)--------------MemoryExec: partitions=1, partition_sizes=[0]

--- a/datafusion/sqllogictest/test_files/join_disable_repartition_joins.slt
+++ b/datafusion/sqllogictest/test_files/join_disable_repartition_joins.slt
@@ -58,7 +58,7 @@ physical_plan
 02)--CoalesceBatchesExec: target_batch_size=8192, fetch=5
 03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(c@0, c@1)], projection=[a@1]
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c], has_header=true
-05)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, c], output_ordering=[a@0 ASC NULLS LAST], has_header=true
 
 # preserve_inner_join
@@ -101,7 +101,7 @@ physical_plan
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c, d], has_header=true
 06)--------CoalesceBatchesExec: target_batch_size=8192
 07)----------FilterExec: d@3 = 3
-08)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b, c, d], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST, c@2 ASC NULLS LAST], has_header=true
 
 # preserve_right_semi_join

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -1343,11 +1343,11 @@ physical_plan
 03)----HashJoinExec: mode=Partitioned, join_type=Inner, on=[(t1_id@0, t2_id@0)], projection=[t1_id@0]
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)------CoalesceBatchesExec: target_batch_size=2
 09)--------RepartitionExec: partitioning=Hash([t2_id@0], 2), input_partitions=2
-10)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+10)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 11)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 # Join on struct
@@ -1365,11 +1365,11 @@ physical_plan
 02)--HashJoinExec: mode=Partitioned, join_type=Inner, on=[(s3@0, s4@0)]
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([s3@0], 2), input_partitions=2
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 07)----CoalesceBatchesExec: target_batch_size=2
 08)------RepartitionExec: partitioning=Hash([s4@0], 2), input_partitions=2
-09)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+09)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 10)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 query ??
@@ -1408,11 +1408,11 @@ physical_plan
 04)------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(t1_id@0, t2_id@0)], projection=[t1_id@0]
 05)--------CoalesceBatchesExec: target_batch_size=2
 06)----------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 09)--------CoalesceBatchesExec: target_batch_size=2
 10)----------RepartitionExec: partitioning=Hash([t2_id@0], 2), input_partitions=2
-11)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query TT
@@ -1439,11 +1439,11 @@ physical_plan
 07)------------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(t1_id@0, t2_id@0)], projection=[t1_id@0]
 08)--------------CoalesceBatchesExec: target_batch_size=2
 09)----------------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-10)------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+10)------------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 11)--------------------MemoryExec: partitions=1, partition_sizes=[1]
 12)--------------CoalesceBatchesExec: target_batch_size=2
 13)----------------RepartitionExec: partitioning=Hash([t2_id@0], 2), input_partitions=2
-14)------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+14)------------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 15)--------------------MemoryExec: partitions=1, partition_sizes=[1]
 
 statement ok
@@ -1507,10 +1507,10 @@ physical_plan
 03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(join_t1.t1_id + Int64(11)@3, CAST(join_t2.t2_id AS Int64)@3)], projection=[t1_id@0, t1_name@1, t1_int@2, t2_id@4, t2_name@5, t2_int@6]
 04)------CoalescePartitionsExec
 05)--------ProjectionExec: expr=[t1_id@0 as t1_id, t1_name@1 as t1_name, t1_int@2 as t1_int, CAST(t1_id@0 AS Int64) + 11 as join_t1.t1_id + Int64(11)]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)------ProjectionExec: expr=[t2_id@0 as t2_id, t2_name@1 as t2_name, t2_int@2 as t2_int, CAST(t2_id@0 AS Int64) as CAST(join_t2.t2_id AS Int64)]
-09)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+09)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 10)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 statement ok
@@ -1534,12 +1534,12 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([join_t1.t1_id + Int64(11)@3], 2), input_partitions=2
 06)----------ProjectionExec: expr=[t1_id@0 as t1_id, t1_name@1 as t1_name, t1_int@2 as t1_int, CAST(t1_id@0 AS Int64) + 11 as join_t1.t1_id + Int64(11)]
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 09)------CoalesceBatchesExec: target_batch_size=2
 10)--------RepartitionExec: partitioning=Hash([CAST(join_t2.t2_id AS Int64)@3], 2), input_partitions=2
 11)----------ProjectionExec: expr=[t2_id@0 as t2_id, t2_name@1 as t2_name, t2_int@2 as t2_int, CAST(t2_id@0 AS Int64) as CAST(join_t2.t2_id AS Int64)]
-12)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+12)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 13)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 # Both side expr key inner join
@@ -1564,10 +1564,10 @@ physical_plan
 03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(join_t2.t2_id + UInt32(1)@1, join_t1.t1_id + UInt32(12)@2)], projection=[t2_id@0, t1_id@2, t1_name@3]
 04)------CoalescePartitionsExec
 05)--------ProjectionExec: expr=[t2_id@0 as t2_id, t2_id@0 + 1 as join_t2.t2_id + UInt32(1)]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)------ProjectionExec: expr=[t1_id@0 as t1_id, t1_name@1 as t1_name, t1_id@0 + 12 as join_t1.t1_id + UInt32(12)]
-09)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+09)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 10)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 statement ok
@@ -1591,12 +1591,12 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([join_t2.t2_id + UInt32(1)@1], 2), input_partitions=2
 06)----------ProjectionExec: expr=[t2_id@0 as t2_id, t2_id@0 + 1 as join_t2.t2_id + UInt32(1)]
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 09)------CoalesceBatchesExec: target_batch_size=2
 10)--------RepartitionExec: partitioning=Hash([join_t1.t1_id + UInt32(12)@2], 2), input_partitions=2
 11)----------ProjectionExec: expr=[t1_id@0 as t1_id, t1_name@1 as t1_name, t1_id@0 + 12 as join_t1.t1_id + UInt32(12)]
-12)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+12)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 13)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 # Left side expr key inner join
@@ -1622,7 +1622,7 @@ physical_plan
 03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t2_id@0, join_t1.t1_id + UInt32(11)@2)], projection=[t2_id@0, t1_id@1, t1_name@2]
 04)------MemoryExec: partitions=1, partition_sizes=[1]
 05)------ProjectionExec: expr=[t1_id@0 as t1_id, t1_name@1 as t1_name, t1_id@0 + 11 as join_t1.t1_id + UInt32(11)]
-06)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 statement ok
@@ -1646,12 +1646,12 @@ physical_plan
 03)----HashJoinExec: mode=Partitioned, join_type=Inner, on=[(t2_id@0, join_t1.t1_id + UInt32(11)@2)], projection=[t2_id@0, t1_id@1, t1_name@2]
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([t2_id@0], 2), input_partitions=2
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)------CoalesceBatchesExec: target_batch_size=2
 09)--------RepartitionExec: partitioning=Hash([join_t1.t1_id + UInt32(11)@2], 2), input_partitions=2
 10)----------ProjectionExec: expr=[t1_id@0 as t1_id, t1_name@1 as t1_name, t1_id@0 + 11 as join_t1.t1_id + UInt32(11)]
-11)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 # Right side expr key inner join
@@ -1677,9 +1677,9 @@ physical_plan
 03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(join_t2.t2_id - UInt32(11)@1, t1_id@0)], projection=[t2_id@0, t1_id@2, t1_name@3]
 04)------CoalescePartitionsExec
 05)--------ProjectionExec: expr=[t2_id@0 as t2_id, t2_id@0 - 11 as join_t2.t2_id - UInt32(11)]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
-08)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+08)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 09)--------MemoryExec: partitions=1, partition_sizes=[1]
 
 statement ok
@@ -1704,11 +1704,11 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([join_t2.t2_id - UInt32(11)@1], 2), input_partitions=2
 06)----------ProjectionExec: expr=[t2_id@0 as t2_id, t2_id@0 - 11 as join_t2.t2_id - UInt32(11)]
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 09)------CoalesceBatchesExec: target_batch_size=2
 10)--------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-11)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 # Select wildcard with expr key inner join
@@ -1732,7 +1732,7 @@ physical_plan
 02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@0, join_t2.t2_id - UInt32(11)@3)], projection=[t1_id@0, t1_name@1, t1_int@2, t2_id@3, t2_name@4, t2_int@5]
 03)----MemoryExec: partitions=1, partition_sizes=[1]
 04)----ProjectionExec: expr=[t2_id@0 as t2_id, t2_name@1 as t2_name, t2_int@2 as t2_int, t2_id@0 - 11 as join_t2.t2_id - UInt32(11)]
-05)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)--------MemoryExec: partitions=1, partition_sizes=[1]
 
 statement ok
@@ -1754,12 +1754,12 @@ physical_plan
 02)--HashJoinExec: mode=Partitioned, join_type=Inner, on=[(t1_id@0, join_t2.t2_id - UInt32(11)@3)], projection=[t1_id@0, t1_name@1, t1_int@2, t2_id@3, t2_name@4, t2_int@5]
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 07)----CoalesceBatchesExec: target_batch_size=2
 08)------RepartitionExec: partitioning=Hash([join_t2.t2_id - UInt32(11)@3], 2), input_partitions=2
 09)--------ProjectionExec: expr=[t2_id@0 as t2_id, t2_name@1 as t2_name, t2_int@2 as t2_int, t2_id@0 - 11 as join_t2.t2_id - UInt32(11)]
-10)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+10)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 11)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 #####
@@ -2084,11 +2084,11 @@ physical_plan
 03)----CoalescePartitionsExec
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------FilterExec: t2_int@1 > 1, projection=[t2_id@0]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)----CoalesceBatchesExec: target_batch_size=2
 09)------FilterExec: t1_id@0 > 10
-10)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+10)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 11)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 query II
@@ -2123,11 +2123,11 @@ physical_plan
 02)--CoalescePartitionsExec
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------FilterExec: t1_id@0 > 22
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 07)--CoalesceBatchesExec: target_batch_size=2
 08)----FilterExec: t2_id@0 > 11
-09)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+09)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 10)--------MemoryExec: partitions=1, partition_sizes=[1]
 
 query II
@@ -2601,11 +2601,11 @@ physical_plan
 02)--HashJoinExec: mode=Partitioned, join_type=Inner, on=[(millis@2, millis@2)]
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([millis@2], 2), input_partitions=2
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 07)----CoalesceBatchesExec: target_batch_size=2
 08)------RepartitionExec: partitioning=Hash([millis@2], 2), input_partitions=2
-09)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+09)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 10)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 # left_join_using_2
@@ -2774,12 +2774,12 @@ physical_plan
 02)--SortExec: expr=[c1@0 ASC], preserve_partitioning=[true]
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([c1@0], 2), input_partitions=2
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 07)--SortExec: expr=[c1@0 ASC], preserve_partitioning=[true]
 08)----CoalesceBatchesExec: target_batch_size=2
 09)------RepartitionExec: partitioning=Hash([c1@0], 2), input_partitions=2
-10)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+10)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 11)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 # sort_merge_join_on_date32 inner sort merge join on data type (Date32)
@@ -2806,12 +2806,12 @@ physical_plan
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([CAST(t1.c3 AS Decimal128(10, 2))@4], 2), input_partitions=2
 06)----------ProjectionExec: expr=[c1@0 as c1, c2@1 as c2, c3@2 as c3, c4@3 as c4, CAST(c3@2 AS Decimal128(10, 2)) as CAST(t1.c3 AS Decimal128(10, 2))]
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 09)----SortExec: expr=[c3@2 ASC], preserve_partitioning=[true]
 10)------CoalesceBatchesExec: target_batch_size=2
 11)--------RepartitionExec: partitioning=Hash([c3@2], 2), input_partitions=2
-12)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+12)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 13)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 # sort_merge_join_on_decimal right join on data type (Decimal)
@@ -2868,12 +2868,12 @@ physical_plan
 03)----HashJoinExec: mode=Partitioned, join_type=RightSemi, on=[(t2_id@0, t1_id@0)]
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([t2_id@0], 2), input_partitions=2
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)------SortExec: expr=[t1_id@0 ASC NULLS LAST], preserve_partitioning=[true]
 09)--------CoalesceBatchesExec: target_batch_size=2
 10)----------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-11)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query IT rowsort
@@ -2909,12 +2909,12 @@ physical_plan
 03)----HashJoinExec: mode=Partitioned, join_type=RightSemi, on=[(t2_id@0, t1_id@0)]
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([t2_id@0], 2), input_partitions=2
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)------SortExec: expr=[t1_id@0 ASC NULLS LAST], preserve_partitioning=[true]
 09)--------CoalesceBatchesExec: target_batch_size=2
 10)----------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-11)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query IT
@@ -2971,7 +2971,7 @@ physical_plan
 03)----HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(t2_id@0, t1_id@0)]
 04)------MemoryExec: partitions=1, partition_sizes=[1]
 05)------SortExec: expr=[t1_id@0 ASC NULLS LAST], preserve_partitioning=[true]
-06)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 query IT rowsort
@@ -3007,7 +3007,7 @@ physical_plan
 03)----HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(t2_id@0, t1_id@0)]
 04)------MemoryExec: partitions=1, partition_sizes=[1]
 05)------SortExec: expr=[t1_id@0 ASC NULLS LAST], preserve_partitioning=[true]
-06)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 query IT
@@ -3065,12 +3065,12 @@ physical_plan
 03)----HashJoinExec: mode=Partitioned, join_type=RightSemi, on=[(t2_id@0, t1_id@0)], filter=t2_name@1 != t1_name@0
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([t2_id@0], 2), input_partitions=2
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)------SortExec: expr=[t1_id@0 ASC NULLS LAST], preserve_partitioning=[true]
 09)--------CoalesceBatchesExec: target_batch_size=2
 10)----------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-11)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query ITI rowsort
@@ -3087,12 +3087,12 @@ physical_plan
 03)----HashJoinExec: mode=Partitioned, join_type=RightSemi, on=[(t2_id@0, t1_id@0)], filter=t2_name@0 != t1_name@1
 04)------CoalesceBatchesExec: target_batch_size=2
 05)--------RepartitionExec: partitioning=Hash([t2_id@0], 2), input_partitions=2
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
 08)------SortExec: expr=[t1_id@0 ASC NULLS LAST], preserve_partitioning=[true]
 09)--------CoalesceBatchesExec: target_batch_size=2
 10)----------RepartitionExec: partitioning=Hash([t1_id@0], 2), input_partitions=2
-11)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query ITI rowsort
@@ -3147,7 +3147,7 @@ physical_plan
 03)----HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(t2_id@0, t1_id@0)], filter=t2_name@1 != t1_name@0
 04)------MemoryExec: partitions=1, partition_sizes=[1]
 05)------SortExec: expr=[t1_id@0 ASC NULLS LAST], preserve_partitioning=[true]
-06)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 query ITI rowsort
@@ -3164,7 +3164,7 @@ physical_plan
 03)----HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(t2_id@0, t1_id@0)], filter=t2_name@0 != t1_name@1
 04)------MemoryExec: partitions=1, partition_sizes=[1]
 05)------SortExec: expr=[t1_id@0 ASC NULLS LAST], preserve_partitioning=[true]
-06)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)----------MemoryExec: partitions=1, partition_sizes=[1]
 
 query ITI rowsort
@@ -3244,13 +3244,13 @@ physical_plan
 02)--SortMergeJoin: join_type=Inner, on=[(a@1, a@1)]
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([a@1], 2), input_partitions=2, preserve_order=true, sort_exprs=a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST, rn1@5 ASC NULLS LAST
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------ProjectionExec: expr=[a0@0 as a0, a@1 as a, b@2 as b, c@3 as c, d@4 as d, row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING@5 as rn1]
 07)------------BoundedWindowAggExec: wdw=[row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING: Ok(Field { name: "row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", data_type: UInt64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(NULL)), is_causal: false }], mode=[Sorted]
 08)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 09)----CoalesceBatchesExec: target_batch_size=2
 10)------RepartitionExec: partitioning=Hash([a@1], 2), input_partitions=2, preserve_order=true, sort_exprs=a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST
-11)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 # sort merge join should propagate ordering equivalence of the right side
@@ -3278,11 +3278,11 @@ physical_plan
 02)--SortMergeJoin: join_type=Right, on=[(a@1, a@1)]
 03)----CoalesceBatchesExec: target_batch_size=2
 04)------RepartitionExec: partitioning=Hash([a@1], 2), input_partitions=2, preserve_order=true, sort_exprs=a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 07)----CoalesceBatchesExec: target_batch_size=2
 08)------RepartitionExec: partitioning=Hash([a@1], 2), input_partitions=2, preserve_order=true, sort_exprs=a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST, rn1@5 ASC NULLS LAST
-09)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+09)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 10)----------ProjectionExec: expr=[a0@0 as a0, a@1 as a, b@2 as b, c@3 as c, d@4 as d, row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING@5 as rn1]
 11)------------BoundedWindowAggExec: wdw=[row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING: Ok(Field { name: "row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", data_type: UInt64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(NULL)), is_causal: false }], mode=[Sorted]
 12)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
@@ -3321,14 +3321,14 @@ physical_plan
 04)------SortExec: expr=[a@1 ASC], preserve_partitioning=[true]
 05)--------CoalesceBatchesExec: target_batch_size=2
 06)----------RepartitionExec: partitioning=Hash([a@1], 2), input_partitions=2
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------ProjectionExec: expr=[a0@0 as a0, a@1 as a, b@2 as b, c@3 as c, d@4 as d, row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING@5 as rn1]
 09)----------------BoundedWindowAggExec: wdw=[row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING: Ok(Field { name: "row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", data_type: UInt64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(NULL)), is_causal: false }], mode=[Sorted]
 10)------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 11)------SortExec: expr=[a@1 ASC], preserve_partitioning=[true]
 12)--------CoalesceBatchesExec: target_batch_size=2
 13)----------RepartitionExec: partitioning=Hash([a@1], 2), input_partitions=2
-14)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+14)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 15)--------------ProjectionExec: expr=[a0@0 as a0, a@1 as a, b@2 as b, c@3 as c, d@4 as d, row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING@5 as rn1]
 16)----------------BoundedWindowAggExec: wdw=[row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING: Ok(Field { name: "row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", data_type: UInt64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(NULL)), is_causal: false }], mode=[Sorted]
 17)------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
@@ -3507,11 +3507,11 @@ physical_plan
 09)----------------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(a@0, a@0)]
 10)------------------CoalesceBatchesExec: target_batch_size=2
 11)--------------------RepartitionExec: partitioning=Hash([a@0], 2), input_partitions=2
-12)----------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+12)----------------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 13)------------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b, c], output_ordering=[a@0 ASC, b@1 ASC NULLS LAST, c@2 ASC NULLS LAST], has_header=true
 14)------------------CoalesceBatchesExec: target_batch_size=2
 15)--------------------RepartitionExec: partitioning=Hash([a@0], 2), input_partitions=2
-16)----------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+16)----------------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 17)------------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], output_ordering=[a@0 ASC, b@1 ASC NULLS LAST], has_header=true
 
 query TT
@@ -3528,7 +3528,7 @@ logical_plan
 physical_plan
 01)NestedLoopJoinExec: join_type=Inner, filter=a@1 < a@0
 02)--CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
-03)--RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)--OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)----CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 # Currently datafusion can pushdown filter conditions with scalar UDF into
@@ -3547,7 +3547,7 @@ logical_plan
 physical_plan
 01)NestedLoopJoinExec: join_type=Inner, filter=example(CAST(a@0 AS Float64), CAST(a@1 AS Float64)) > 3
 02)--CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
-03)--RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)--OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)----CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 ####
@@ -4344,12 +4344,12 @@ physical_plan
 05)--------RepartitionExec: partitioning=Hash([a@0], 2), input_partitions=2
 06)----------CoalesceBatchesExec: target_batch_size=3
 07)------------FilterExec: b@1 > 3, projection=[a@0]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 10)------SortExec: expr=[c@2 DESC], preserve_partitioning=[true]
 11)--------CoalesceBatchesExec: target_batch_size=3
 12)----------RepartitionExec: partitioning=Hash([a@0], 2), input_partitions=2
-13)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+13)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 14)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query TT
@@ -4371,12 +4371,12 @@ physical_plan
 05)--------RepartitionExec: partitioning=Hash([a@0], 2), input_partitions=2
 06)----------CoalesceBatchesExec: target_batch_size=3
 07)------------FilterExec: b@1 > 3, projection=[a@0]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 10)------SortExec: expr=[c@2 DESC NULLS LAST], preserve_partitioning=[true]
 11)--------CoalesceBatchesExec: target_batch_size=3
 12)----------RepartitionExec: partitioning=Hash([a@0], 2), input_partitions=2
-13)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+13)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 14)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query III

--- a/datafusion/sqllogictest/test_files/json.slt
+++ b/datafusion/sqllogictest/test_files/json.slt
@@ -60,7 +60,7 @@ physical_plan
 01)AggregateExec: mode=Final, gby=[], aggr=[count(*)]
 02)--CoalescePartitionsExec
 03)----AggregateExec: mode=Partial, gby=[], aggr=[count(*)]
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------JsonExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/2.json]]}
 
 query ?

--- a/datafusion/sqllogictest/test_files/limit.slt
+++ b/datafusion/sqllogictest/test_files/limit.slt
@@ -369,7 +369,7 @@ physical_plan
 01)AggregateExec: mode=Final, gby=[], aggr=[count(*)]
 02)--CoalescePartitionsExec
 03)----AggregateExec: mode=Partial, gby=[], aggr=[count(*)]
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------ProjectionExec: expr=[]
 06)----------GlobalLimitExec: skip=6, fetch=3
 07)------------CoalesceBatchesExec: target_batch_size=8192, fetch=9
@@ -402,7 +402,7 @@ physical_plan
 01)AggregateExec: mode=FinalPartitioned, gby=[i@0 as i], aggr=[]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----RepartitionExec: partitioning=Hash([i@0], 4), input_partitions=4
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------AggregateExec: mode=Partial, gby=[i@0 as i], aggr=[]
 06)----------MemoryExec: partitions=1
 
@@ -635,7 +635,7 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=8192
 06)----------RepartitionExec: partitioning=Hash([b@0], 4), input_partitions=4
 07)------------AggregateExec: mode=Partial, gby=[b@1 as b], aggr=[sum(ordered_table.a)]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)----------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], has_header=true
 
 # Applying offset & limit when multiple streams from union
@@ -661,11 +661,11 @@ physical_plan
 03)----UnionExec
 04)------SortExec: TopK(fetch=14), expr=[c@0 DESC], preserve_partitioning=[true]
 05)--------ProjectionExec: expr=[CAST(c@0 AS Int64) as c]
-06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 07)------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c], output_ordering=[c@0 ASC NULLS LAST], has_header=true
 08)------SortExec: TopK(fetch=14), expr=[c@0 DESC], preserve_partitioning=[true]
 09)--------ProjectionExec: expr=[CAST(d@0 AS Int64) as c]
-10)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+10)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 11)------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[d], has_header=true
 
 # Applying LIMIT & OFFSET to subquery.

--- a/datafusion/sqllogictest/test_files/monotonic_projection_test.slt
+++ b/datafusion/sqllogictest/test_files/monotonic_projection_test.slt
@@ -46,7 +46,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [a_big@0 ASC NULLS LAST, b@1 ASC NULLS LAST]
 02)--ProjectionExec: expr=[CAST(a@0 AS Int64) as a_big, b@1 as b]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST], has_header=true
 
 query TT
@@ -62,7 +62,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [a@0 ASC NULLS LAST, b@2 ASC NULLS LAST]
 02)--ProjectionExec: expr=[a@0 as a, CAST(a@0 AS Int64) as a_big, b@1 as b]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST], has_header=true
 
 # Cast to larger types as well as preserving ordering
@@ -83,7 +83,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [a_big@1 ASC NULLS LAST, b@2 ASC NULLS LAST]
 02)--ProjectionExec: expr=[a@0 as a, CAST(a@0 AS Int64) as a_big, b@1 as b]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST], has_header=true
 
 # test for common rename
@@ -135,7 +135,7 @@ physical_plan
 01)SortPreservingMergeExec: [a_str@0 ASC NULLS LAST, b@1 ASC NULLS LAST]
 02)--SortExec: expr=[a_str@0 ASC NULLS LAST, b@1 ASC NULLS LAST], preserve_partitioning=[true]
 03)----ProjectionExec: expr=[CAST(a@0 AS Utf8) as a_str, b@1 as b]
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST], has_header=true
 
 # We cannot determine a+b is ordered from the
@@ -170,5 +170,5 @@ physical_plan
 01)SortPreservingMergeExec: [sum_expr@0 ASC NULLS LAST]
 02)--SortExec: expr=[sum_expr@0 ASC NULLS LAST], preserve_partitioning=[true]
 03)----ProjectionExec: expr=[CAST(a@0 + b@1 AS Int64) as sum_expr, a@0 as a, b@1 as b]
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST], has_header=true

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -456,7 +456,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [result@0 ASC NULLS LAST]
 02)--ProjectionExec: expr=[b@1 + a@0 + c@2 as result]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b, c], output_orderings=[[a@0 ASC NULLS LAST], [b@1 ASC NULLS LAST], [c@2 ASC NULLS LAST]], has_header=true
 
 statement ok
@@ -487,7 +487,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [db15@0 ASC NULLS LAST]
 02)--ProjectionExec: expr=[date_bin(IntervalMonthDayNano { months: 0, days: 0, nanoseconds: 900000000000 }, ts@0, 1659537600000000000) as db15]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/timestamps.csv]]}, projection=[ts], output_ordering=[ts@0 ASC NULLS LAST], has_header=false
 
 query TT
@@ -502,7 +502,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [dt_day@0 ASC NULLS LAST]
 02)--ProjectionExec: expr=[date_trunc(DAY, ts@0) as dt_day]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/timestamps.csv]]}, projection=[ts], output_ordering=[ts@0 ASC NULLS LAST], has_header=false
 
 statement ok
@@ -545,7 +545,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [atan_c11@0 ASC NULLS LAST]
 02)--ProjectionExec: expr=[atan(c11@0) as atan_c11]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c11], output_ordering=[c11@0 ASC NULLS LAST], has_header=true
 
 query TT
@@ -560,7 +560,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [ceil_c11@0 ASC NULLS LAST]
 02)--ProjectionExec: expr=[ceil(c11@0) as ceil_c11]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c11], output_ordering=[c11@0 ASC NULLS LAST], has_header=true
 
 query TT
@@ -575,7 +575,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [log_c11_base_c12@0 ASC NULLS LAST]
 02)--ProjectionExec: expr=[log(c12@1, CAST(c11@0 AS Float64)) as log_c11_base_c12]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c11, c12], output_orderings=[[c11@0 ASC NULLS LAST], [c12@1 DESC NULLS LAST]], has_header=true
 
 query TT
@@ -590,7 +590,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [log_c12_base_c11@0 DESC NULLS LAST]
 02)--ProjectionExec: expr=[log(CAST(c11@0 AS Float64), c12@1) as log_c12_base_c11]
-03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c11, c12], output_orderings=[[c11@0 ASC NULLS LAST], [c12@1 DESC NULLS LAST]], has_header=true
 
 statement ok
@@ -783,7 +783,7 @@ physical_plan
 05)--------AggregateExec: mode=FinalPartitioned, gby=[t@0 as t], aggr=[]
 06)----------CoalesceBatchesExec: target_batch_size=8192
 07)------------RepartitionExec: partitioning=Hash([t@0], 2), input_partitions=2
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 09)----------------AggregateExec: mode=Partial, gby=[t@0 as t], aggr=[]
 10)------------------ProjectionExec: expr=[column1@0 as t]
 11)--------------------ValuesExec
@@ -791,7 +791,7 @@ physical_plan
 13)--------AggregateExec: mode=FinalPartitioned, gby=[t@0 as t], aggr=[]
 14)----------CoalesceBatchesExec: target_batch_size=8192
 15)------------RepartitionExec: partitioning=Hash([t@0], 2), input_partitions=2
-16)--------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+16)--------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 17)----------------AggregateExec: mode=Partial, gby=[t@0 as t], aggr=[]
 18)------------------ProjectionExec: expr=[column1@0 as t]
 19)--------------------ValuesExec
@@ -1024,7 +1024,7 @@ physical_plan
 01)SortPreservingMergeExec: [c_str@0 ASC NULLS LAST], fetch=5
 02)--SortExec: TopK(fetch=5), expr=[c_str@0 ASC NULLS LAST], preserve_partitioning=[true]
 03)----ProjectionExec: expr=[CAST(c@0 AS Utf8) as c_str]
-04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c], output_ordering=[c@0 ASC NULLS LAST], has_header=true
 
 
@@ -1054,7 +1054,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [c_bigint@0 ASC NULLS LAST], fetch=5
 02)--ProjectionExec: expr=[CAST(c@0 AS Int64) as c_bigint]
-03)----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c], output_ordering=[c@0 ASC NULLS LAST], has_header=true
 
 statement ok
@@ -1090,7 +1090,7 @@ physical_plan
 01)SortPreservingMergeExec: [abs_c@0 ASC NULLS LAST], fetch=5
 02)--SortExec: TopK(fetch=5), expr=[abs_c@0 ASC NULLS LAST], preserve_partitioning=[true]
 03)----ProjectionExec: expr=[abs(c@0) as abs_c]
-04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c], output_ordering=[c@0 ASC NULLS LAST], has_header=true
 
 statement ok
@@ -1124,7 +1124,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [abs_c@0 ASC NULLS LAST], fetch=5
 02)--ProjectionExec: expr=[abs(c@0) as abs_c]
-03)----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c], output_ordering=[c@0 ASC NULLS LAST], has_header=true
 
 # Boolean to integer casts preserve the order.
@@ -1150,7 +1150,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [c@0 ASC NULLS LAST]
 02)--ProjectionExec: expr=[CAST(inc_col@0 > desc_col@1 AS Int32) as c]
-03)----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_1.csv]]}, projection=[inc_col, desc_col], output_orderings=[[inc_col@0 ASC NULLS LAST], [desc_col@1 DESC]], has_header=true
 
 # Union a query with the actual data and one with a constant
@@ -1173,7 +1173,7 @@ logical_plan
 03)----TableScan: ordered_table projection=[a, b]
 physical_plan
 01)ProjectionExec: expr=[a@0 + b@1 as sum1]
-02)--RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+02)--OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 03)----SortExec: TopK(fetch=1), expr=[a@0 ASC NULLS LAST], preserve_partitioning=[false]
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], has_header=true
 
@@ -1212,7 +1212,7 @@ logical_plan
 03)----TableScan: ordered_table projection=[a, b]
 physical_plan
 01)ProjectionExec: expr=[a@0 + b@1 as sum1]
-02)--RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+02)--OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 03)----SortExec: TopK(fetch=1), expr=[a@0 ASC NULLS LAST], preserve_partitioning=[false]
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], has_header=true
 

--- a/datafusion/sqllogictest/test_files/parquet.slt
+++ b/datafusion/sqllogictest/test_files/parquet.slt
@@ -410,7 +410,7 @@ logical_plan
 physical_plan
 01)CoalesceBatchesExec: target_batch_size=8192
 02)--FilterExec: CAST(binary_col@0 AS Utf8View) LIKE %a% AND CAST(largebinary_col@1 AS Utf8View) LIKE %a% AND CAST(binaryview_col@2 AS Utf8View) LIKE %a%
-03)----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)------ParquetExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet/binary_as_string.parquet]]}, projection=[binary_col, largebinary_col, binaryview_col], predicate=CAST(binary_col@0 AS Utf8View) LIKE %a% AND CAST(largebinary_col@1 AS Utf8View) LIKE %a% AND CAST(binaryview_col@2 AS Utf8View) LIKE %a%
 
 
@@ -458,7 +458,7 @@ logical_plan
 physical_plan
 01)CoalesceBatchesExec: target_batch_size=8192
 02)--FilterExec: binary_col@0 LIKE %a% AND largebinary_col@1 LIKE %a% AND binaryview_col@2 LIKE %a%
-03)----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)------ParquetExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet/binary_as_string.parquet]]}, projection=[binary_col, largebinary_col, binaryview_col], predicate=binary_col@0 LIKE %a% AND largebinary_col@1 LIKE %a% AND binaryview_col@2 LIKE %a%
 
 
@@ -509,7 +509,7 @@ logical_plan
 physical_plan
 01)CoalesceBatchesExec: target_batch_size=8192
 02)--FilterExec: binary_col@0 LIKE %a% AND largebinary_col@1 LIKE %a% AND binaryview_col@2 LIKE %a%
-03)----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)------ParquetExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet/binary_as_string.parquet]]}, projection=[binary_col, largebinary_col, binaryview_col], predicate=binary_col@0 LIKE %a% AND largebinary_col@1 LIKE %a% AND binaryview_col@2 LIKE %a%
 
 

--- a/datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt
+++ b/datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt
@@ -112,7 +112,7 @@ physical_plan
 02)--SortExec: expr=[a@0 ASC NULLS LAST], preserve_partitioning=[true]
 03)----CoalesceBatchesExec: target_batch_size=8192
 04)------FilterExec: b@1 > 2, projection=[a@0]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=2
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=2
 06)----------ParquetExec: file_groups={2 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_filter_pushdown/parquet_table/1.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_filter_pushdown/parquet_table/2.parquet]]}, projection=[a, b], predicate=b@1 > 2, pruning_predicate=CASE WHEN b_null_count@1 = b_row_count@2 THEN false ELSE b_max@0 > 2 END, required_guarantees=[]
 
 # also test querying on columns that are not in all the files

--- a/datafusion/sqllogictest/test_files/predicates.slt
+++ b/datafusion/sqllogictest/test_files/predicates.slt
@@ -674,13 +674,13 @@ physical_plan
 04)------RepartitionExec: partitioning=Hash([l_partkey@0], 4), input_partitions=4
 05)--------CoalesceBatchesExec: target_batch_size=8192
 06)----------FilterExec: l_quantity@1 >= Some(100),15,2 AND l_quantity@1 <= Some(1100),15,2 OR l_quantity@1 >= Some(1000),15,2 AND l_quantity@1 <= Some(2000),15,2 OR l_quantity@1 >= Some(2000),15,2 AND l_quantity@1 <= Some(3000),15,2
-07)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 08)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/tpch-csv/lineitem.csv]]}, projection=[l_partkey, l_quantity], has_header=true
 09)----CoalesceBatchesExec: target_batch_size=8192
 10)------RepartitionExec: partitioning=Hash([p_partkey@0], 4), input_partitions=4
 11)--------CoalesceBatchesExec: target_batch_size=8192
 12)----------FilterExec: (p_brand@1 = Brand#12 AND p_size@2 <= 5 OR p_brand@1 = Brand#23 AND p_size@2 <= 10 OR p_brand@1 = Brand#34 AND p_size@2 <= 15) AND p_size@2 >= 1
-13)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+13)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 14)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/tpch-csv/part.csv]]}, projection=[p_partkey, p_brand, p_size], has_header=true
 
 ########
@@ -766,13 +766,13 @@ physical_plan
 05)--------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(l_partkey@0, p_partkey@0)], projection=[l_extendedprice@1, l_discount@2, p_partkey@3]
 06)----------CoalesceBatchesExec: target_batch_size=8192
 07)------------RepartitionExec: partitioning=Hash([l_partkey@0], 4), input_partitions=4
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)----------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/tpch-csv/lineitem.csv]]}, projection=[l_partkey, l_extendedprice, l_discount], has_header=true
 10)----------CoalesceBatchesExec: target_batch_size=8192
 11)------------RepartitionExec: partitioning=Hash([p_partkey@0], 4), input_partitions=4
 12)--------------CoalesceBatchesExec: target_batch_size=8192
 13)----------------FilterExec: p_brand@1 = Brand#12 OR p_brand@1 = Brand#23, projection=[p_partkey@0]
-14)------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+14)------------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 15)--------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/tpch-csv/part.csv]]}, projection=[p_partkey, p_brand], has_header=true
 16)------CoalesceBatchesExec: target_batch_size=8192
 17)--------RepartitionExec: partitioning=Hash([ps_partkey@0], 4), input_partitions=1

--- a/datafusion/sqllogictest/test_files/repartition.slt
+++ b/datafusion/sqllogictest/test_files/repartition.slt
@@ -47,7 +47,7 @@ physical_plan
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----RepartitionExec: partitioning=Hash([column1@0], 4), input_partitions=4
 04)------AggregateExec: mode=Partial, gby=[column1@0 as column1], aggr=[sum(parquet_table.column2)]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------ParquetExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition/parquet_table/2.parquet]]}, projection=[column1, column2]
 
 # disable round robin repartitioning
@@ -125,7 +125,7 @@ physical_plan
 02)--CoalescePartitionsExec
 03)----CoalesceBatchesExec: target_batch_size=8192, fetch=5
 04)------FilterExec: c3@2 > 0
-05)--------RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(3), input_partitions=1
 06)----------StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true
 
 # Start repratition on empty column test.

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1404,7 +1404,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [a@0 ASC NULLS LAST]
 02)--ProjectionExec: expr=[a@0 as a, a@0 + b@1 as annotated_data_finite2.a + annotated_data_finite2.b]
-03)----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+03)----OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 04)------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST], has_header=true
 
 # since query below doesn't computation
@@ -1442,7 +1442,7 @@ physical_plan
 01)SortPreservingMergeExec: [b@2 ASC NULLS LAST, c@3 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: a@1 = 0
-04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 # source is ordered by a,b,c
@@ -1463,7 +1463,7 @@ physical_plan
 01)SortPreservingMergeExec: [c@3 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: a@1 = 0 AND b@2 = 0
-04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 # source is ordered by a,b,c
@@ -1484,7 +1484,7 @@ physical_plan
 01)SortPreservingMergeExec: [b@2 ASC NULLS LAST, c@3 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: a@1 = 0 AND b@2 = 0
-04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 # source is ordered by a,b,c
@@ -1505,7 +1505,7 @@ physical_plan
 01)SortPreservingMergeExec: [a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: a@1 = 0 AND b@2 = 0
-04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 # source is ordered by a,b,c
@@ -1527,7 +1527,7 @@ physical_plan
 02)--SortExec: expr=[c@3 ASC NULLS LAST], preserve_partitioning=[true]
 03)----CoalesceBatchesExec: target_batch_size=8192
 04)------FilterExec: a@1 = 0 OR b@2 = 0
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 # When ordering lost during projection, we shouldn't keep the SortExec.
@@ -1551,7 +1551,7 @@ physical_plan
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----RepartitionExec: partitioning=Hash([c2@0], 2), input_partitions=2
 04)------AggregateExec: mode=Partial, gby=[c2@0 as c2], aggr=[count(*)]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------ProjectionExec: expr=[c2@0 as c2]
 07)------------SortExec: TopK(fetch=4), expr=[c1@1 ASC NULLS LAST, c2@0 ASC NULLS LAST], preserve_partitioning=[false]
 08)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c2, c1], has_header=true
@@ -1573,7 +1573,7 @@ physical_plan
 01)SortPreservingMergeExec: [CAST(round(CAST(b@2 AS Float64)) AS Int32) ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: CAST(round(CAST(b@2 AS Float64)) AS Int32) = a@1
-04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 05)--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
 

--- a/datafusion/sqllogictest/test_files/subquery.slt
+++ b/datafusion/sqllogictest/test_files/subquery.slt
@@ -208,11 +208,11 @@ physical_plan
 06)----------CoalesceBatchesExec: target_batch_size=2
 07)------------RepartitionExec: partitioning=Hash([t2_id@0], 4), input_partitions=4
 08)--------------AggregateExec: mode=Partial, gby=[t2_id@0 as t2_id], aggr=[sum(t2.t2_int)]
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 10)------------------MemoryExec: partitions=1, partition_sizes=[1]
 11)------CoalesceBatchesExec: target_batch_size=2
 12)--------RepartitionExec: partitioning=Hash([t1_id@0], 4), input_partitions=4
-13)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+13)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 14)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query II rowsort
@@ -244,11 +244,11 @@ physical_plan
 06)----------CoalesceBatchesExec: target_batch_size=2
 07)------------RepartitionExec: partitioning=Hash([t2_id@0], 4), input_partitions=4
 08)--------------AggregateExec: mode=Partial, gby=[t2_id@0 as t2_id], aggr=[sum(t2.t2_int * Float64(1))]
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 10)------------------MemoryExec: partitions=1, partition_sizes=[1]
 11)------CoalesceBatchesExec: target_batch_size=2
 12)--------RepartitionExec: partitioning=Hash([t1_id@0], 4), input_partitions=4
-13)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+13)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 14)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query IR rowsort
@@ -280,11 +280,11 @@ physical_plan
 06)----------CoalesceBatchesExec: target_batch_size=2
 07)------------RepartitionExec: partitioning=Hash([t2_id@0], 4), input_partitions=4
 08)--------------AggregateExec: mode=Partial, gby=[t2_id@0 as t2_id], aggr=[sum(t2.t2_int)]
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 10)------------------MemoryExec: partitions=1, partition_sizes=[1]
 11)------CoalesceBatchesExec: target_batch_size=2
 12)--------RepartitionExec: partitioning=Hash([t1_id@0], 4), input_partitions=4
-13)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+13)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 14)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query II rowsort
@@ -319,11 +319,11 @@ physical_plan
 08)--------------CoalesceBatchesExec: target_batch_size=2
 09)----------------RepartitionExec: partitioning=Hash([t2_id@0], 4), input_partitions=4
 10)------------------AggregateExec: mode=Partial, gby=[t2_id@0 as t2_id], aggr=[sum(t2.t2_int)]
-11)--------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+11)--------------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 12)----------------------MemoryExec: partitions=1, partition_sizes=[1]
 13)------CoalesceBatchesExec: target_batch_size=2
 14)--------RepartitionExec: partitioning=Hash([t1_id@0], 4), input_partitions=4
-15)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+15)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 16)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query II rowsort
@@ -1152,11 +1152,11 @@ physical_plan
 04)------HashJoinExec: mode=Partitioned, join_type=LeftMark, on=[(t1_id@0, t2_id@0)]
 05)--------CoalesceBatchesExec: target_batch_size=2
 06)----------RepartitionExec: partitioning=Hash([t1_id@0], 4), input_partitions=4
-07)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 09)--------CoalesceBatchesExec: target_batch_size=2
 10)----------RepartitionExec: partitioning=Hash([t2_id@0], 4), input_partitions=4
-11)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+11)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 12)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 statement ok

--- a/datafusion/sqllogictest/test_files/subquery_sort.slt
+++ b/datafusion/sqllogictest/test_files/subquery_sort.slt
@@ -125,7 +125,7 @@ physical_plan
 06)----------CoalesceBatchesExec: target_batch_size=8192
 07)------------RepartitionExec: partitioning=Hash([c1@0], 4), input_partitions=4
 08)--------------AggregateExec: mode=Partial, gby=[c1@0 as c1], aggr=[first_value(sink_table.c1) ORDER BY [sink_table.c1 ASC NULLS LAST, sink_table.c3 DESC NULLS FIRST, sink_table.c9 ASC NULLS LAST], first_value(sink_table.c2) ORDER BY [sink_table.c1 ASC NULLS LAST, sink_table.c3 DESC NULLS FIRST, sink_table.c9 ASC NULLS LAST], first_value(sink_table.c3) ORDER BY [sink_table.c1 ASC NULLS LAST, sink_table.c3 DESC NULLS FIRST, sink_table.c9 ASC NULLS LAST], first_value(sink_table.c9) ORDER BY [sink_table.c1 ASC NULLS LAST, sink_table.c3 DESC NULLS FIRST, sink_table.c9 ASC NULLS LAST]]
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 10)------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2, c3, c9], has_header=true
 
 

--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -236,7 +236,7 @@ physical_plan
 01)AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=4
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=3
 05)--------AggregateExec: mode=Partial, gby=[name@0 as name], aggr=[]
 06)----------UnionExec
 07)------------MemoryExec: partitions=1, partition_sizes=[1]
@@ -313,12 +313,12 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=2
 06)----------RepartitionExec: partitioning=Hash([id@0, name@1], 4), input_partitions=4
 07)------------AggregateExec: mode=Partial, gby=[id@0 as id, name@1 as name], aggr=[]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 10)------CoalesceBatchesExec: target_batch_size=2
 11)--------RepartitionExec: partitioning=Hash([CAST(t2.id AS Int32)@2, name@1], 4), input_partitions=4
 12)----------ProjectionExec: expr=[id@0 as id, name@1 as name, CAST(id@0 AS Int32) as CAST(t2.id AS Int32)]
-13)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+13)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 14)--------------MemoryExec: partitions=1, partition_sizes=[1]
 15)--ProjectionExec: expr=[CAST(id@0 AS Int32) as id, name@1 as name]
 16)----CoalesceBatchesExec: target_batch_size=2
@@ -330,11 +330,11 @@ physical_plan
 22)----------------CoalesceBatchesExec: target_batch_size=2
 23)------------------RepartitionExec: partitioning=Hash([id@0, name@1], 4), input_partitions=4
 24)--------------------AggregateExec: mode=Partial, gby=[id@0 as id, name@1 as name], aggr=[]
-25)----------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+25)----------------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 26)------------------------MemoryExec: partitions=1, partition_sizes=[1]
 27)--------CoalesceBatchesExec: target_batch_size=2
 28)----------RepartitionExec: partitioning=Hash([id@0, name@1], 4), input_partitions=4
-29)------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+29)------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 30)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 
@@ -387,11 +387,11 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=2
 06)----------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=4
 07)------------AggregateExec: mode=Partial, gby=[name@0 as name], aggr=[]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 10)------CoalesceBatchesExec: target_batch_size=2
 11)--------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=4
-12)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+12)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 13)------------MemoryExec: partitions=1, partition_sizes=[1]
 14)--CoalesceBatchesExec: target_batch_size=2
 15)----HashJoinExec: mode=Partitioned, join_type=LeftAnti, on=[(name@0, name@0)]
@@ -399,11 +399,11 @@ physical_plan
 17)--------CoalesceBatchesExec: target_batch_size=2
 18)----------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=4
 19)------------AggregateExec: mode=Partial, gby=[name@0 as name], aggr=[]
-20)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+20)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 21)----------------MemoryExec: partitions=1, partition_sizes=[1]
 22)------CoalesceBatchesExec: target_batch_size=2
 23)--------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=4
-24)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+24)----------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 25)------------MemoryExec: partitions=1, partition_sizes=[1]
 
 # union_upcast_types
@@ -422,11 +422,11 @@ physical_plan
 02)--UnionExec
 03)----SortExec: TopK(fetch=5), expr=[c9@1 DESC], preserve_partitioning=[true]
 04)------ProjectionExec: expr=[c1@0 as c1, CAST(c9@1 AS Int64) as c9]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c9], has_header=true
 07)----SortExec: TopK(fetch=5), expr=[c9@1 DESC], preserve_partitioning=[true]
 08)------ProjectionExec: expr=[c1@0 as c1, CAST(c3@1 AS Int64) as c9]
-09)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+09)--------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 10)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c3], has_header=true
 
 query TI
@@ -463,13 +463,13 @@ physical_plan
 05)--------CoalesceBatchesExec: target_batch_size=2
 06)----------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=4
 07)------------AggregateExec: mode=Partial, gby=[name@0 as name], aggr=[]
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+08)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 09)----------------MemoryExec: partitions=1, partition_sizes=[1]
 10)------AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[]
 11)--------CoalesceBatchesExec: target_batch_size=2
 12)----------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=4
 13)------------AggregateExec: mode=Partial, gby=[name@0 as name], aggr=[]
-14)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+14)--------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 15)----------------MemoryExec: partitions=1, partition_sizes=[1]
 
 # Union with limit push down 3 children test case
@@ -524,7 +524,7 @@ physical_plan
 12)----------------------AggregateExec: mode=Partial, gby=[c1@0 as c1], aggr=[]
 13)------------------------CoalesceBatchesExec: target_batch_size=2
 14)--------------------------FilterExec: c13@1 != C2GT5KVyOPZpgKVl110TyZO0NcJ434, projection=[c1@0]
-15)----------------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+15)----------------------------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 16)------------------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c13], has_header=true
 17)------ProjectionExec: expr=[1 as cnt]
 18)--------PlaceholderRowExec

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -601,7 +601,7 @@ logical_plan
 05)--------TableScan: recursive_unnest_table projection=[column3]
 physical_plan
 01)UnnestExec
-02)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+02)--OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 03)----ProjectionExec: expr=[__unnest_placeholder(recursive_unnest_table.column3,depth=1)@0 as __unnest_placeholder(UNNEST(recursive_unnest_table.column3)), column3@1 as column3]
 04)------UnnestExec
 05)--------ProjectionExec: expr=[column3@0 as __unnest_placeholder(recursive_unnest_table.column3), column3@0 as column3]
@@ -660,7 +660,7 @@ physical_plan
 01)ProjectionExec: expr=[__unnest_placeholder(UNNEST(recursive_unnest_table.column3)[c1],depth=2)@0 as UNNEST(UNNEST(UNNEST(recursive_unnest_table.column3)[c1])), column3@1 as column3]
 02)--UnnestExec
 03)----ProjectionExec: expr=[get_field(__unnest_placeholder(recursive_unnest_table.column3,depth=1)@0, c1) as __unnest_placeholder(UNNEST(recursive_unnest_table.column3)[c1]), column3@1 as column3]
-04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------OnDemandRepartitionExec: partitioning=OnDemand(4), input_partitions=1
 05)--------UnnestExec
 06)----------ProjectionExec: expr=[column3@0 as __unnest_placeholder(recursive_unnest_table.column3), column3@0 as column3]
 07)------------MemoryExec: partitions=1, partition_sizes=[1]

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -1320,7 +1320,7 @@ physical_plan
 08)--------------SortExec: expr=[c1@0 ASC NULLS LAST, c2@1 ASC NULLS LAST], preserve_partitioning=[true]
 09)----------------CoalesceBatchesExec: target_batch_size=4096
 10)------------------RepartitionExec: partitioning=Hash([c1@0, c2@1], 2), input_partitions=2
-11)--------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+11)--------------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 12)----------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2, c4], has_header=true
 
 
@@ -1733,7 +1733,7 @@ physical_plan
 06)----------SortPreservingMergeExec: [__common_expr_1@0 DESC, c9@3 DESC, c2@1 ASC NULLS LAST]
 07)------------SortExec: expr=[__common_expr_1@0 DESC, c9@3 DESC, c2@1 ASC NULLS LAST], preserve_partitioning=[true]
 08)--------------ProjectionExec: expr=[c3@1 + c4@2 as __common_expr_1, c2@0 as c2, c3@1 as c3, c9@3 as c9]
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+09)----------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 10)------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c2, c3, c4, c9], has_header=true
 
 
@@ -1784,7 +1784,7 @@ physical_plan
 09)----------------AggregateExec: mode=Partial, gby=[c1@0 as c1], aggr=[]
 10)------------------CoalesceBatchesExec: target_batch_size=4096
 11)--------------------FilterExec: c13@1 != C2GT5KVyOPZpgKVl110TyZO0NcJ434, projection=[c1@0]
-12)----------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+12)----------------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 13)------------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c13], has_header=true
 
 
@@ -1826,7 +1826,7 @@ physical_plan
 04)------SortExec: expr=[c3@0 ASC NULLS LAST, c9@1 DESC], preserve_partitioning=[true]
 05)--------CoalesceBatchesExec: target_batch_size=4096
 06)----------RepartitionExec: partitioning=Hash([c3@0], 2), input_partitions=2
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------ProjectionExec: expr=[c3@1 as c3, c9@2 as c9, sum(aggregate_test_100.c9) ORDER BY [aggregate_test_100.c3 DESC NULLS FIRST, aggregate_test_100.c9 DESC NULLS FIRST, aggregate_test_100.c2 ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@3 as sum(aggregate_test_100.c9) ORDER BY [aggregate_test_100.c3 DESC NULLS FIRST, aggregate_test_100.c9 DESC NULLS FIRST, aggregate_test_100.c2 ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]
 09)----------------BoundedWindowAggExec: wdw=[sum(aggregate_test_100.c9) ORDER BY [aggregate_test_100.c3 DESC NULLS FIRST, aggregate_test_100.c9 DESC NULLS FIRST, aggregate_test_100.c2 ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Ok(Field { name: "sum(aggregate_test_100.c9) ORDER BY [aggregate_test_100.c3 DESC NULLS FIRST, aggregate_test_100.c9 DESC NULLS FIRST, aggregate_test_100.c2 ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(Int16(NULL)), end_bound: CurrentRow, is_causal: false }], mode=[Sorted]
 10)------------------SortExec: expr=[c3@1 DESC, c9@2 DESC, c2@0 ASC NULLS LAST], preserve_partitioning=[false]
@@ -1868,7 +1868,7 @@ physical_plan
 04)------SortExec: expr=[c1@0 ASC NULLS LAST], preserve_partitioning=[true]
 05)--------CoalesceBatchesExec: target_batch_size=4096
 06)----------RepartitionExec: partitioning=Hash([c1@0], 2), input_partitions=2
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1], has_header=true
 
 query TI
@@ -1997,7 +1997,7 @@ physical_plan
 04)------SortExec: expr=[c1@0 ASC NULLS LAST], preserve_partitioning=[true]
 05)--------CoalesceBatchesExec: target_batch_size=4096
 06)----------RepartitionExec: partitioning=Hash([c1@0], 2), input_partitions=2
-07)------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+07)------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 08)--------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1], has_header=true
 
 statement ok
@@ -2026,7 +2026,7 @@ physical_plan
 07)------------SortExec: expr=[c1@0 ASC NULLS LAST, c9@1 ASC NULLS LAST], preserve_partitioning=[true]
 08)--------------CoalesceBatchesExec: target_batch_size=4096
 09)----------------RepartitionExec: partitioning=Hash([c1@0], 2), input_partitions=2
-10)------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+10)------------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 11)--------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c9], has_header=true
 
 # test_window_agg_with_global_limit
@@ -2046,7 +2046,7 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[], aggr=[array_agg(aggregate_test_100.c13)]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[], aggr=[array_agg(aggregate_test_100.c13)]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------SortExec: TopK(fetch=1), expr=[c13@0 ASC NULLS LAST], preserve_partitioning=[false]
 07)------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c13], has_header=true
 
@@ -3276,7 +3276,7 @@ physical_plan
 13)------------------------CoalesceBatchesExec: target_batch_size=4096
 14)--------------------------RepartitionExec: partitioning=Hash([a@1, b@2], 2), input_partitions=2, preserve_order=true, sort_exprs=a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST, __common_expr_1@0 ASC NULLS LAST
 15)----------------------------ProjectionExec: expr=[CAST(a@0 AS Int64) as __common_expr_1, a@0 as a, b@1 as b, c@2 as c, d@3 as d]
-16)------------------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+16)------------------------------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 17)--------------------------------StreamingTableExec: partition_sizes=1, projection=[a, b, c, d], infinite_source=true, output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST, c@2 ASC NULLS LAST]
 
 # reset the partition number 1 again
@@ -3625,7 +3625,7 @@ physical_plan
 03)----BoundedWindowAggExec: wdw=[avg(multiple_ordered_table_inf.d) PARTITION BY [multiple_ordered_table_inf.d] ORDER BY [multiple_ordered_table_inf.a ASC NULLS LAST] RANGE BETWEEN 10 PRECEDING AND CURRENT ROW: Ok(Field { name: "avg(multiple_ordered_table_inf.d) PARTITION BY [multiple_ordered_table_inf.d] ORDER BY [multiple_ordered_table_inf.a ASC NULLS LAST] RANGE BETWEEN 10 PRECEDING AND CURRENT ROW", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(Int32(10)), end_bound: CurrentRow, is_causal: false }], mode=[Linear]
 04)------CoalesceBatchesExec: target_batch_size=4096
 05)--------RepartitionExec: partitioning=Hash([d@4], 2), input_partitions=2, preserve_order=true, sort_exprs=a@1 ASC NULLS LAST, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST
-06)----------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+06)----------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 07)------------StreamingTableExec: partition_sizes=1, projection=[a0, a, b, c, d], infinite_source=true, output_orderings=[[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST], [c@3 ASC NULLS LAST]]
 
 # CTAS with NTILE function
@@ -4120,7 +4120,7 @@ physical_plan
 02)--BoundedWindowAggExec: wdw=[count(*) PARTITION BY [a.a] ORDER BY [a.a ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Ok(Field { name: "count(*) PARTITION BY [a.a] ORDER BY [a.a ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(Int64(NULL)), end_bound: CurrentRow, is_causal: false }], mode=[Sorted]
 03)----CoalesceBatchesExec: target_batch_size=4096
 04)------RepartitionExec: partitioning=Hash([a@0], 2), input_partitions=2
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------CoalesceBatchesExec: target_batch_size=4096
 07)------------FilterExec: a@0 = 1
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
@@ -4143,7 +4143,7 @@ physical_plan
 02)--BoundedWindowAggExec: wdw=[row_number() PARTITION BY [a.a] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING: Ok(Field { name: "row_number() PARTITION BY [a.a] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", data_type: UInt64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(NULL)), is_causal: false }], mode=[Sorted]
 03)----CoalesceBatchesExec: target_batch_size=4096
 04)------RepartitionExec: partitioning=Hash([a@0], 2), input_partitions=2
-05)--------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+05)--------OnDemandRepartitionExec: partitioning=OnDemand(2), input_partitions=1
 06)----------CoalesceBatchesExec: target_batch_size=4096
 07)------------FilterExec: a@0 = 1
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
@@ -5054,7 +5054,7 @@ select b, row_number() over (order by a) from (select TRUE as a, 1 as b);
 1 1
 
 # test window functions on boolean columns
-query T
+statement count 0
 create table t1 (id int, bool_col boolean) as values 
     (1, true),
     (2, false),

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -551,6 +551,7 @@ pub fn to_substrait_rel(
             let partition_count = match repartition.partitioning_scheme {
                 Partitioning::RoundRobinBatch(num) => num,
                 Partitioning::Hash(_, num) => num,
+                Partitioning::OnDemand(num) => num,
                 Partitioning::DistributeBy(_) => {
                     return not_impl_err!(
                         "Physical plan does not support DistributeBy partitioning"
@@ -559,9 +560,10 @@ pub fn to_substrait_rel(
             };
             // ref: https://substrait.io/relations/physical_relations/#exchange-types
             let exchange_kind = match &repartition.partitioning_scheme {
-                Partitioning::RoundRobinBatch(_) => {
+                Partitioning::RoundRobinBatch(_) | Partitioning::OnDemand(_) => {
                     ExchangeKind::RoundRobin(RoundRobin::default())
                 }
+
                 Partitioning::Hash(exprs, _) => {
                     let fields = exprs
                         .iter()


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow #55
Replacing all `RoundRobins` with `OnDemandRepartitions` so that we can check every possible scenario on DataFusion.



## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Replace `RepartitionExec::Hash` with `OnDemandRepartitionExec`

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## BenchMark
### Summary
On-demand repartitioning can partially eliminate the performance impact of pull-based SPM, particularly when processing large datasets like TPCH-50. The impact becomes more noticeable as the number of partitions increases beyond the default setting of 11 partitions, such as when using 20 partitions.




```
--------------------
Benchmark clickbench_partitioned.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃      main ┃ on-demand-repartition-replace-roundrobin ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │    1.05ms │                                   0.99ms │ +1.06x faster │
│ QQuery 1     │   22.69ms │                                  21.14ms │ +1.07x faster │
│ QQuery 2     │   69.23ms │                                  61.15ms │ +1.13x faster │
│ QQuery 3     │   54.82ms │                                  53.21ms │     no change │
│ QQuery 4     │  513.63ms │                                 487.34ms │ +1.05x faster │
│ QQuery 5     │  588.91ms │                                 529.72ms │ +1.11x faster │
│ QQuery 6     │   27.69ms │                                  23.04ms │ +1.20x faster │
│ QQuery 7     │   26.67ms │                                  23.99ms │ +1.11x faster │
│ QQuery 8     │  562.01ms │                                 533.78ms │ +1.05x faster │
│ QQuery 9     │  796.04ms │                                 749.67ms │ +1.06x faster │
│ QQuery 10    │  180.21ms │                                 170.51ms │ +1.06x faster │
│ QQuery 11    │  199.47ms │                                 186.45ms │ +1.07x faster │
│ QQuery 12    │  588.14ms │                                 579.45ms │     no change │
│ QQuery 13    │  894.36ms │                                 817.26ms │ +1.09x faster │
│ QQuery 14    │  558.84ms │                                 534.40ms │     no change │
│ QQuery 15    │  593.67ms │                                 581.05ms │     no change │
│ QQuery 16    │ 1182.24ms │                                1150.80ms │     no change │
│ QQuery 17    │ 1092.40ms │                                1060.30ms │     no change │
│ QQuery 18    │ 3208.44ms │                                3122.19ms │     no change │
│ QQuery 19    │   43.15ms │                                  44.62ms │     no change │
│ QQuery 20    │  760.08ms │                                 786.14ms │     no change │
│ QQuery 21    │  962.54ms │                                1011.72ms │  1.05x slower │
│ QQuery 22    │ 1848.72ms │                                2009.89ms │  1.09x slower │
│ QQuery 23    │ 6246.57ms │                                6601.85ms │  1.06x slower │
│ QQuery 24    │  320.15ms │                                 324.72ms │     no change │
│ QQuery 25    │  280.08ms │                                 281.85ms │     no change │
│ QQuery 26    │  357.00ms │                                 350.79ms │     no change │
│ QQuery 27    │ 1154.08ms │                                1163.36ms │     no change │
│ QQuery 28    │ 9319.67ms │                                9467.86ms │     no change │
│ QQuery 29    │  417.70ms │                                 416.07ms │     no change │
│ QQuery 30    │  519.73ms │                                 509.11ms │     no change │
│ QQuery 31    │  533.26ms │                                 521.96ms │     no change │
│ QQuery 32    │ 4049.22ms │                                4261.51ms │  1.05x slower │
│ QQuery 33    │ 4856.03ms │                                4472.98ms │ +1.09x faster │
│ QQuery 34    │ 5150.46ms │                                4913.45ms │     no change │
│ QQuery 35    │  830.13ms │                                 811.03ms │     no change │
│ QQuery 36    │  107.73ms │                                 103.71ms │     no change │
│ QQuery 37    │   50.66ms │                                  48.84ms │     no change │
│ QQuery 38    │   69.57ms │                                  71.13ms │     no change │
│ QQuery 39    │  197.94ms │                                 200.36ms │     no change │
│ QQuery 40    │   21.89ms │                                  21.57ms │     no change │
│ QQuery 41    │   20.41ms │                                  18.98ms │ +1.07x faster │
│ QQuery 42    │   27.47ms │                                  27.70ms │     no change │
└──────────────┴───────────┴──────────────────────────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Benchmark Summary                                       ┃            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Total Time (main)                                       │ 49304.76ms │
│ Total Time (on-demand-repartition-replace-roundrobin)   │ 49127.59ms │
│ Average Time (main)                                     │  1146.62ms │
│ Average Time (on-demand-repartition-replace-roundrobin) │  1142.50ms │
│ Queries Faster                                          │         14 │
│ Queries Slower                                          │          4 │
│ Queries with No Change                                  │         25 │
└─────────────────────────────────────────────────────────┴────────────┘
--------------------
Benchmark tpch_sf1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃     main ┃ on-demand-repartition-replace-roundrobin ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  96.27ms │                                  94.30ms │     no change │
│ QQuery 2     │  22.95ms │                                  20.35ms │ +1.13x faster │
│ QQuery 3     │  40.61ms │                                  37.45ms │ +1.08x faster │
│ QQuery 4     │  25.28ms │                                  22.62ms │ +1.12x faster │
│ QQuery 5     │  62.13ms │                                  55.67ms │ +1.12x faster │
│ QQuery 6     │  18.40ms │                                  18.11ms │     no change │
│ QQuery 7     │  79.23ms │                                  75.42ms │     no change │
│ QQuery 8     │  48.13ms │                                  49.74ms │     no change │
│ QQuery 9     │  69.41ms │                                  66.23ms │     no change │
│ QQuery 10    │  59.81ms │                                  55.57ms │ +1.08x faster │
│ QQuery 11    │  14.53ms │                                  14.29ms │     no change │
│ QQuery 12    │  36.95ms │                                  34.11ms │ +1.08x faster │
│ QQuery 13    │  33.12ms │                                  33.23ms │     no change │
│ QQuery 14    │  29.62ms │                                  29.71ms │     no change │
│ QQuery 15    │  43.12ms │                                  42.83ms │     no change │
│ QQuery 16    │  16.36ms │                                  14.57ms │ +1.12x faster │
│ QQuery 17    │  92.58ms │                                  88.99ms │     no change │
│ QQuery 18    │ 125.10ms │                                 118.45ms │ +1.06x faster │
│ QQuery 19    │  51.32ms │                                  49.86ms │     no change │
│ QQuery 20    │  39.93ms │                                  39.75ms │     no change │
│ QQuery 21    │  96.21ms │                                  93.27ms │     no change │
│ QQuery 22    │  23.68ms │                                  15.53ms │ +1.52x faster │
└──────────────┴──────────┴──────────────────────────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Summary                                       ┃           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Total Time (main)                                       │ 1124.73ms │
│ Total Time (on-demand-repartition-replace-roundrobin)   │ 1070.03ms │
│ Average Time (main)                                     │   51.12ms │
│ Average Time (on-demand-repartition-replace-roundrobin) │   48.64ms │
│ Queries Faster                                          │         9 │
│ Queries Slower                                          │         0 │
│ Queries with No Change                                  │        13 │
└─────────────────────────────────────────────────────────┴───────────┘
--------------------
Benchmark tpch_sf10.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃      main ┃ on-demand-repartition-replace-roundrobin ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  845.56ms │                                 892.64ms │  1.06x slower │
│ QQuery 2     │  133.56ms │                                 126.30ms │ +1.06x faster │
│ QQuery 3     │  417.37ms │                                 410.98ms │     no change │
│ QQuery 4     │  206.50ms │                                 208.02ms │     no change │
│ QQuery 5     │  658.68ms │                                 621.53ms │ +1.06x faster │
│ QQuery 6     │  138.54ms │                                 140.86ms │     no change │
│ QQuery 7     │  904.95ms │                                1008.06ms │  1.11x slower │
│ QQuery 8     │  695.60ms │                                 625.28ms │ +1.11x faster │
│ QQuery 9     │ 1069.79ms │                                1034.73ms │     no change │
│ QQuery 10    │  581.17ms │                                 549.70ms │ +1.06x faster │
│ QQuery 11    │   92.11ms │                                  86.46ms │ +1.07x faster │
│ QQuery 12    │  286.87ms │                                 283.17ms │     no change │
│ QQuery 13    │  379.85ms │                                 420.27ms │  1.11x slower │
│ QQuery 14    │  260.79ms │                                 236.91ms │ +1.10x faster │
│ QQuery 15    │  393.16ms │                                 418.78ms │  1.07x slower │
│ QQuery 16    │  102.55ms │                                  94.43ms │ +1.09x faster │
│ QQuery 17    │ 1104.93ms │                                1101.63ms │     no change │
│ QQuery 18    │ 1726.72ms │                                1666.72ms │     no change │
│ QQuery 19    │  402.42ms │                                 391.32ms │     no change │
│ QQuery 20    │  393.42ms │                                 364.85ms │ +1.08x faster │
│ QQuery 21    │ 1528.32ms │                                1384.15ms │ +1.10x faster │
│ QQuery 22    │  142.34ms │                                 132.42ms │ +1.07x faster │
└──────────────┴───────────┴──────────────────────────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Benchmark Summary                                       ┃            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Total Time (main)                                       │ 12465.22ms │
│ Total Time (on-demand-repartition-replace-roundrobin)   │ 12199.22ms │
│ Average Time (main)                                     │   566.60ms │
│ Average Time (on-demand-repartition-replace-roundrobin) │   554.51ms │
│ Queries Faster                                          │         10 │
│ Queries Slower                                          │          4 │
│ Queries with No Change                                  │          8 │
└─────────────────────────────────────────────────────────┴────────────┘
--------------------
Benchmark tpch_sf50.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃       main ┃ on-demand-repartition-replace-roundrobin ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  4156.30ms │                                4117.73ms │     no change │
│ QQuery 2     │   867.36ms │                                 832.79ms │     no change │
│ QQuery 3     │  2137.40ms │                                2068.66ms │     no change │
│ QQuery 4     │   986.37ms │                                 986.32ms │     no change │
│ QQuery 5     │  3631.56ms │                                3374.30ms │ +1.08x faster │
│ QQuery 6     │   688.99ms │                                 683.07ms │     no change │
│ QQuery 7     │ 16741.48ms │                               14672.63ms │ +1.14x faster │
│ QQuery 8     │  3888.69ms │                                3636.21ms │ +1.07x faster │
│ QQuery 9     │ 42770.71ms │                                7909.49ms │ +5.41x faster │
│ QQuery 10    │  2906.62ms │                                2856.60ms │     no change │
│ QQuery 11    │   822.01ms │                                 818.53ms │     no change │
│ QQuery 12    │  1424.10ms │                                1469.93ms │     no change │
│ QQuery 13    │  2340.27ms │                                2621.12ms │  1.12x slower │
│ QQuery 14    │  1087.98ms │                                1192.52ms │  1.10x slower │
│ QQuery 15    │  2552.58ms │                                2600.42ms │     no change │
│ QQuery 16    │   434.50ms │                                 412.45ms │ +1.05x faster │
│ QQuery 17    │  6127.07ms │                                6095.06ms │     no change │
│ QQuery 18    │ 24462.64ms │                               16711.71ms │ +1.46x faster │
│ QQuery 19    │  1912.85ms │                                1846.36ms │     no change │
│ QQuery 20    │  2209.30ms │                                2405.32ms │  1.09x slower │
│ QQuery 21    │  8924.97ms │                                8736.71ms │     no change │
│ QQuery 22    │   740.03ms │                                 693.93ms │ +1.07x faster │
└──────────────┴────────────┴──────────────────────────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Benchmark Summary                                       ┃             ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ Total Time (main)                                       │ 131813.79ms │
│ Total Time (on-demand-repartition-replace-roundrobin)   │  86741.86ms │
│ Average Time (main)                                     │   5991.54ms │
│ Average Time (on-demand-repartition-replace-roundrobin) │   3942.81ms │
│ Queries Faster                                          │           7 │
│ Queries Slower                                          │           3 │
│ Queries with No Change                                  │          12 │
└─────────────────────────────────────────────────────────┴─────────────┘
```
