### PR TITLE
Introduce linear tag for udaf, and support basic transforming in no grouping case

### DIFF
--- a/datafusion-examples/examples/parse_sql_expr.rs
+++ b/datafusion-examples/examples/parse_sql_expr.rs
@@ -101,7 +101,7 @@ async fn query_parquet_demo() -> Result<()> {
         )
         .await?;
 
-    let df = df
+    let df: datafusion::prelude::DataFrame = df
         .clone()
         .select(vec![
             df.parse_sql_expr("int_col")?,

--- a/datafusion-examples/examples/query-http-csv.rs
+++ b/datafusion-examples/examples/query-http-csv.rs
@@ -39,18 +39,30 @@ async fn main() -> Result<()> {
     // register csv file with the execution context
     ctx.register_csv(
         "aggregate_test_100",
-        "https://github.com/apache/arrow-testing/raw/master/data/csv/aggregate_test_100.csv",
+        "/Users/kamille/Desktop/github/datafusion/testing/data/csv/aggregate_test_100.csv",
         CsvReadOptions::new(),
     )
     .await?;
 
     // execute the query
+    // let df = ctx
+    //     .sql("SELECT c1, c2, MIN(c3) + SUM(c3) + 4 FROM aggregate_test_100 GROUP BY c1, c2 LIMIT 1")
+    //     .await?;
     let df = ctx
-        .sql("SELECT c1,c2,c3 FROM aggregate_test_100 LIMIT 5")
+        .sql("SELECT c1, c2, MIN(c3) + 3 FROM aggregate_test_100 GROUP BY c1, c2 LIMIT 1")
         .await?;
 
+    let plan = df.logical_plan();
+    println!("{plan}");
     // print the results
     df.show().await?;
+
+    // let df = ctx
+    // .sql("SELECT c1, c2, MIN(c3) FROM aggregate_test_100 GROUP BY GROUPING SETS ((c1,c2),(c1),(c2)) LIMIT 1")
+    // .await?;
+
+    // // print the results
+    // df.show().await?;
 
     Ok(())
 }

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1236,6 +1236,7 @@ impl LogicalPlanBuilder {
     ) -> Result<Self> {
         let group_expr = normalize_cols(group_expr, &self.plan)?;
         let aggr_expr = normalize_cols(aggr_expr, &self.plan)?;
+        println!("{aggr_expr:?}");
 
         let group_expr = if self.options.add_implicit_group_by_exprs {
             add_group_by_exprs_from_dependencies(group_expr, self.plan.schema())?

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1236,7 +1236,6 @@ impl LogicalPlanBuilder {
     ) -> Result<Self> {
         let group_expr = normalize_cols(group_expr, &self.plan)?;
         let aggr_expr = normalize_cols(aggr_expr, &self.plan)?;
-        println!("{aggr_expr:?}");
 
         let group_expr = if self.options.add_implicit_group_by_exprs {
             add_group_by_exprs_from_dependencies(group_expr, self.plan.schema())?

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -940,6 +940,21 @@ pub trait AggregateUDFImpl: Debug + Send + Sync {
     fn set_monotonicity(&self, _data_type: &DataType) -> SetMonotonicity {
         SetMonotonicity::NotMonotonic
     }
+
+    /// If this function is a linear function, return true
+    /// If the function is not, return false
+    ///
+    /// The Linear aggregation function will satisfy such transforming:
+    ///
+    /// ```text
+    ///   f(3x + y) = 3 * f(x) + f(y)
+    ///
+    ///   NOTICE: both `x` and `y` should be non-nullable
+    /// ```
+    ///
+    fn is_linear(&self) -> bool {
+        false
+    }
 }
 
 impl PartialEq for dyn AggregateUDFImpl {

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -325,6 +325,11 @@ impl AggregateUDF {
         self.inner.is_ordered_set_aggregate()
     }
 
+    /// See [`AggregateUDFImpl::is_linear`] for more details.
+    pub fn is_linear(&self) -> bool {
+        self.inner.is_linear()
+    }
+
     /// Returns the documentation for this Aggregate UDF.
     ///
     /// Documentation can be accessed programmatically as well as

--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -266,6 +266,10 @@ impl AggregateUDFImpl for Sum {
             _ => SetMonotonicity::NotMonotonic,
         }
     }
+
+    fn is_linear(&self) -> bool {
+        true
+    }
 }
 
 /// This accumulator computes SUM incrementally

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -61,6 +61,7 @@ pub mod replace_distinct_aggregate;
 pub mod scalar_subquery_to_join;
 pub mod simplify_expressions;
 pub mod single_distinct_to_groupby;
+pub mod transform_linear_aggregation;
 pub mod utils;
 
 #[cfg(test)]

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use datafusion_expr::registry::FunctionRegistry;
 use datafusion_expr::{assert_expected_schema, InvariantLevel};
-use log::{debug, warn};
+use log::{debug, error, warn};
 
 use datafusion_common::alias::AliasGenerator;
 use datafusion_common::config::ConfigOptions;
@@ -402,6 +402,7 @@ impl Optimizer {
                     }
                     // OptimizerRule was unsuccessful, but skipped failed rules is off, return error
                     (Err(e), None) => {
+                        debug!("Optimizer rule '{}' failed, error:{e}", rule.name());
                         return Err(e.context(format!(
                             "Optimizer rule '{}' failed",
                             rule.name()

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -54,6 +54,7 @@ use crate::replace_distinct_aggregate::ReplaceDistinctWithAggregate;
 use crate::scalar_subquery_to_join::ScalarSubqueryToJoin;
 use crate::simplify_expressions::SimplifyExpressions;
 use crate::single_distinct_to_groupby::SingleDistinctToGroupBy;
+use crate::transform_linear_aggregation::TransformLinearAggregation;
 use crate::utils::log_plan;
 
 /// `OptimizerRule`s transforms one [`LogicalPlan`] into another which
@@ -243,6 +244,8 @@ impl Optimizer {
             // The previous optimizations added expressions and projections,
             // that might benefit from the following rules
             Arc::new(EliminateGroupByConstant::new()),
+            // Try to transform linear udaf to reduce computation
+            Arc::new(TransformLinearAggregation::new()),
             Arc::new(CommonSubexprEliminate::new()),
             Arc::new(OptimizeProjections::new()),
         ];

--- a/datafusion/optimizer/src/transform_linear_aggregation.rs
+++ b/datafusion/optimizer/src/transform_linear_aggregation.rs
@@ -1,0 +1,264 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`EliminateGroupByConstant`] removes constant expressions from `GROUP BY` clause
+use std::sync::Arc;
+
+use crate::optimizer::ApplyOrder;
+use crate::{OptimizerConfig, OptimizerRule};
+
+use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::{internal_err, DFSchema, Result};
+use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams, Alias};
+use datafusion_expr::{
+    Aggregate, BinaryExpr, Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder,
+    Operator, Volatility,
+};
+
+/// Optimizer rule that removes constant expressions from `GROUP BY` clause
+/// and places additional projection on top of aggregation, to preserve
+/// original schema
+#[derive(Default, Debug)]
+pub struct TransformLinearAggregation {}
+
+impl TransformLinearAggregation {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for TransformLinearAggregation {
+    fn supports_rewrite(&self) -> bool {
+        true
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>> {
+        match plan {
+            LogicalPlan::Aggregate(aggregate) => {
+                // TODO: transform linear udaf in group by cases
+                // Currently, we only try to transform `aggr_expr` in no grouping cases,
+                // and surely `aggr_expr` should exist
+                if !aggregate.group_expr.is_empty() || aggregate.aggr_expr.is_empty() {
+                    return Ok(Transformed::no(LogicalPlan::Aggregate(aggregate)));
+                }
+
+                // Try to transform `aggr_expr`
+                let mut new_aggr_exprs = Vec::with_capacity(aggregate.aggr_expr.len());
+                let mut new_proj_exprs = Vec::new();
+                let mut transformed = false;
+                let input_schema = aggregate.input.schema();
+                for expr in aggregate.aggr_expr.iter() {
+                    transformed = maybe_transform_aggr_expr(
+                        expr,
+                        input_schema,
+                        &mut new_aggr_exprs,
+                        &mut new_proj_exprs,
+                    )?;
+                }
+
+                // If transform happened, we need to rewrite the old `Aggregate`
+                if !transformed {
+                    return Ok(Transformed::no(LogicalPlan::Aggregate(aggregate)));
+                }
+
+                let transformed_aggregate = LogicalPlan::Aggregate(Aggregate::try_new(
+                    aggregate.input,
+                    aggregate.group_expr.clone(),
+                    new_aggr_exprs,
+                )?);
+
+                let projection_expr =
+                    aggregate.group_expr.into_iter().chain(new_proj_exprs);
+
+                let projection = LogicalPlanBuilder::from(transformed_aggregate)
+                    .project(projection_expr)?
+                    .build()?;
+
+                Ok(Transformed::yes(projection))
+            }
+            _ => Ok(Transformed::no(plan)),
+        }
+    }
+
+    fn name(&self) -> &str {
+        "transform_linear_aggregation"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
+}
+
+/// Try to transform the udaf
+///
+/// It will try to transform if `aggr_expr` satisfies following requirements:
+///   - It is a `linear` udaf
+///   - It should be `not distinct`, `not filter exists`, `not order by exists`
+///   - Only one arg exist in `args`, and it is `non-nullable`
+///
+/// And
+fn maybe_transform_aggr_expr(
+    aggr_expr: &Expr,
+    input_schema: &DFSchema,
+    new_aggr_exprs: &mut Vec<Expr>,
+    new_proj_exprs: &mut Vec<Expr>,
+) -> Result<bool> {
+    let Expr::AggregateFunction(AggregateFunction { func, params }) = aggr_expr else {
+        return internal_err!(
+            "expect Expr::AggregateFunction in aggr_expr, but found:{aggr_expr:?}"
+        );
+    };
+
+    let AggregateFunctionParams {
+        args,
+        distinct,
+        filter,
+        order_by,
+        null_treatment,
+    } = params;
+
+    // Check if we should try to transform
+    if !func.is_linear()
+        || *distinct
+        || filter.is_some()
+        || order_by.is_some()
+        || args.len() != 1
+        || args[0].nullable(input_schema)?
+    {
+        dbg!("return in check transforming failed");
+        new_aggr_exprs.push(aggr_expr.clone());
+        return Ok(false);
+    }
+
+    // For simplicity, we just process the simple situation `aggr(a + b)` in demo
+    // We split it into two aggr exprs: `aggr(a) + aggr(b)`.
+    // And NOTICE, we need to use `Projection` to alias it back to `aggr(a + b)` to
+    // let it parent can still refer to it.
+    let Expr::BinaryExpr(BinaryExpr {
+        left,
+        op: Operator::Plus,
+        right,
+    }) = &args[0]
+    else {
+        dbg!("return in tranform failed");
+        new_aggr_exprs.push(aggr_expr.clone());
+        return Ok(false);
+    };
+
+    // Build the two `new aggr exprs`
+    let aggr1 = Expr::AggregateFunction(AggregateFunction::new_udf(
+        Arc::clone(&func),
+        vec![*left.clone()],
+        *distinct,
+        filter.clone(),
+        order_by.clone(),
+        null_treatment.clone(),
+    ));
+    let aggr2 = Expr::AggregateFunction(AggregateFunction::new_udf(
+        Arc::clone(&func),
+        vec![*right.clone()],
+        *distinct,
+        filter.clone(),
+        order_by.clone(),
+        null_treatment.clone(),
+    ));
+    new_aggr_exprs.extend([aggr1.clone(), aggr2.clone()]);
+
+    // Build the `new proj expr`
+    let (_, proj_name) = aggr_expr.qualified_name();
+    let new_proj_expr = (aggr1 + aggr2).alias(proj_name);
+    new_proj_exprs.push(new_proj_expr);
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assert_optimized_plan_eq_snapshot;
+    use crate::test::*;
+    use crate::Optimizer;
+    use crate::OptimizerContext;
+
+    use arrow::datatypes::DataType;
+    use datafusion_common::Result;
+    use datafusion_expr::expr::ScalarFunction;
+    use datafusion_expr::{
+        col, lit, ColumnarValue, LogicalPlanBuilder, ScalarFunctionArgs, ScalarUDF,
+        ScalarUDFImpl, Signature, TypeSignature,
+    };
+
+    use datafusion_functions_aggregate::expr_fn::count;
+    use datafusion_functions_aggregate::expr_fn::sum;
+
+    use std::sync::Arc;
+
+    macro_rules! assert_optimized_plan_equal {
+            (
+                $plan:expr,
+                @ $expected:literal $(,)?
+            ) => {{
+                let rule: Arc<dyn crate::OptimizerRule + Send + Sync> = Arc::new(TransformLinearAggregation::new());
+                assert_optimized_plan_eq_snapshot!(
+                    rule,
+                    $plan,
+                    @ $expected,
+                )
+            }};
+        }
+
+    #[test]
+    fn test_eliminate_gby_literal() {
+        let scan = test_table_scan().unwrap();
+        let plan = LogicalPlanBuilder::from(scan)
+            .aggregate(Vec::<Expr>::new(), vec![sum(col("c") + col("b"))])
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let rule: Arc<dyn OptimizerRule + Send + Sync> =
+            Arc::new(TransformLinearAggregation::new());
+        let opt_context = OptimizerContext::new().with_max_passes(1);
+        let optimizer = Optimizer::with_rules(vec![Arc::clone(&rule)]);
+        let optimized_plan = optimizer.optimize(plan, &opt_context, |_, _| {}).unwrap();
+        println!("{optimized_plan}");
+
+        // assert_optimized_plan_equal!(plan, @r"
+        // Projection: test.a, UInt32(1), count(test.c)
+        //   Aggregate: groupBy=[[test.a]], aggr=[[count(test.c)]]
+        //     TableScan: test
+        // ")
+    }
+
+    //     #[test]
+    //     fn test_eliminate_constant() -> Result<()> {
+    //         let scan = test_table_scan()?;
+    //         let plan = LogicalPlanBuilder::from(scan)
+    //             .aggregate(vec![lit("test"), lit(123u32)], vec![count(col("c"))])?
+    //             .build()?;
+
+    //         assert_optimized_plan_equal!(plan, @r#"
+    //         Projection: Utf8("test"), UInt32(123), count(test.c)
+    //           Aggregate: groupBy=[[]], aggr=[[count(test.c)]]
+    //             TableScan: test
+    //         "#)
+    //     }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/datafusion/issues/15633

## Rationale for this change

As memtioned above, we can perform transformation for some udafs (like `sum`) to reduce computation.
For example:
```
// Origin
SELECT sum(a + 1) FROM t;

// Transformed (actually, this already faster)
SELECT sum(a) + sum(1) FROM t;

// Simplify `sum(1)`
SELECT sum(a) + count(*) FROM t;
```

But as mentioned in https://github.com/apache/datafusion/issues/15633#issuecomment-2866894705
Such transformation can not always get benefits, so for not introducing regression, my iteration plan is:
- [ ] introduce it in `no grouping` case (this pr)
- [ ] try to introduce it in `group by` case for some pre-defined pattern
- [ ] see can we introduce it in `group by` case more generally

And in this first pr, we just try the first step.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
